### PR TITLE
fix: Use api instead of implementation.

### DIFF
--- a/maps-utils-ktx/build.gradle
+++ b/maps-utils-ktx/build.gradle
@@ -44,7 +44,7 @@ android {
 
 dependencies {
     api deps.kotlin
-    implementation deps.androidMapsUtils
+    api deps.androidMapsUtils
     implementation deps.playServicesMaps
     implementation deps.kotlinxCoroutines
 


### PR DESCRIPTION
Using `api` instead of `implementation` so that consumers can include this library
without needing to also include the AMU library.
