### PR TITLE
build: Add build task when deploying.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ deploy:
   provider: script
   script:
   - openssl aes-256-cbc -K $encrypted_96a824601a6d_key -iv $encrypted_96a824601a6d_iv
-    -in .travis.gpg.enc -out .travis.gpg -d && ./gradlew dokka publish -PsonatypeUsername=${SONATYPE_USERNAME}
+    -in .travis.gpg.enc -out .travis.gpg -d && ./gradlew build dokka publish -PsonatypeUsername=${SONATYPE_USERNAME}
     -PsonatypePassword=${SONATYPE_PASSWORD} -Psigning.keyId=${GPG_KEY_ID} -Psigning.password=${GPG_KEY_PASSPHRASE}
     -Psigning.secretKeyRingFile=../.travis.gpg
   on:


### PR DESCRIPTION
Executing build task when running the deploy step. I think this is why the auto-deploy when pushing a new tag
is failing (i.e. .aar file cannot be found).

See: https://travis-ci.org/github/googlemaps/android-maps-ktx/builds/661312633
