### PR TITLE
fix: Add dependencies of maps-utils-ktx in pom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,16 @@ subprojects { project ->
                     artifact dokkaJar
                     artifact sourcesJar
                 }
+
+                pom.withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+                    project.configurations.api.allDependencies.each { dependency ->
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', dependency.group)
+                        dependencyNode.appendNode('artifactId', dependency.name)
+                        dependencyNode.appendNode('version', dependency.version)
+                    }
+                }
             }
         }
 

--- a/maps-utils-ktx/build.gradle
+++ b/maps-utils-ktx/build.gradle
@@ -40,6 +40,9 @@ android {
         }
     }
 
+    libraryVariants.all {
+        it.generateBuildConfig.enabled = false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
The dependencies node was missing in the published `pom.xml` in maven central. This PR addresses that by adding it. This was verified working in my test app.

Generated `pom.xml` now looks like:

```
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.google.maps.android</groupId>
  <artifactId>maps-utils-ktx</artifactId>
  <version>0.1.1</version>
  <packaging>aar</packaging>
  <name>maps-utils-ktx</name>
  <description>Kotlin extensions (KTX) for Google Maps SDK</description>
  <url>https://github.com/googlemaps/android-maps-ktx</url>
  <organization>
    <name>Google Inc</name>
    <url>http://developers.google.com/maps</url>
  </organization>
  <licenses>
    <license>
      <name>The Apache Software License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  <developers>
    <developer>
      <name>Google Inc.</name>
    </developer>
  </developers>
  <scm>
    <connection>scm:git@github.com:googlemaps/android-maps-ktx.git</connection>
    <developerConnection>scm:git@github.com:googlemaps/android-maps-ktx.git</developerConnection>
    <url>https://github.com/googlemaps/android-maps-ktx</url>
  </scm>
  <dependencies>
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-stdlib-jdk7</artifactId>
      <version>1.3.61</version>
    </dependency>
    <dependency>
      <groupId>com.google.maps.android</groupId>
      <artifactId>android-maps-utils</artifactId>
      <version>1.0.0</version>
    </dependency>
  </dependencies>
</project>
```

Once merged I'll push `0.1.2`

Fixes #13 