### PR TITLE
chore: Bump android-maps-utils Java lib to v1.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
             "minSdk"    : 15,
             "targetSdk" : 29
         ],
-        'androidMapsUtils' : '1.0.0',
+        'androidMapsUtils' : '1.0.2',
         'androidx'         : [
             'appcompat': '1.1.0',
             'coreKtx'  : '1.2.0',


### PR DESCRIPTION
Bump android-maps-utils Java lib to v1.0.2