### PR TITLE
feat: Adding KTX to Maps SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository contains a set a of Kotlin extensions (KTX) for the [Maps SDK fo
 dependencies {
 
     // KTX for the maps SDK library - Coming Soon
-    // implementation 'com.google.maps.android:maps-utils-ktx:<future-version>'
+// implementation 'com.google.maps.android:maps-ktx:<future-version>'
 
     // KTX for the utility library
     implementation 'com.google.maps.android:maps-utils-ktx:0.2'

--- a/README.md
+++ b/README.md
@@ -21,28 +21,58 @@ It enables you to write more concise, idiomatic Kotlin. Each set of extensions c
 ```groovy
 dependencies {
 
-    // KTX for the maps SDK library - Coming Soon
-// implementation 'com.google.maps.android:maps-ktx:<future-version>'
+    // KTX for the Maps SDK library - Coming Soon
+    // implementation 'com.google.maps.android:maps-ktx:<future-version>'
 
-    // KTX for the utility library
+    // KTX for the Maps SDK for Android Utility library
     implementation 'com.google.maps.android:maps-utils-ktx:0.2'
 }
 ```
 
 ## Example Usage
 
-With this KTX library, you should be able to take advantage of several Kotlin language features such as:
+With this KTX library, you should be able to take advantage of several Kotlin language features such as extension functions, named parameters and default arguments, destructuring declarations, and coroutines.
+
+### Maps SDK KTX
 
 #### Extension functions
 
-_Before_:
+Adding a `Marker`:
+
+_Before_
+```java
+GoogleMap googleMap = // ...
+LatLng sydney = new LatLng(-33.852, 151.211);
+MarkerOptions markerOptions = new MarkerOptions()
+    .position(Sydney)
+    .title("Marker in Sydney");
+Marker marker = googleMap.addMarker(markerOptions);
+```
+
+_After_
+```kotlin
+Val googleMap = // ...
+val sydney = LatLng(-33.852, 151.211)
+val marker = googleMap.addMarker {
+    position(sydney)
+    title("Marker in Sydney")
+}
+```
+
+### Maps SDK for Android Utilities KTX
+
+#### Extension functions
+
+Checking if a `LatLng` is contained within a `Polygon`:
+
+_Before_
 ```java
 Polygon polygon = // some polygon
 LatLng latlng = // some latlng
 boolean result = PolygonUtil.containsLocation(latlng, polygon.getPoints(), true);
 ```
 
-_After_:
+_After_
 ```kotlin
 val polygon: Polygon = // some polygon
 val latlng: LatLng = // some latlng
@@ -51,7 +81,9 @@ val result: Boolean = polygon.contains(latLng)
 
 #### Named parameters and default arguments
 
-_Before_:
+Creating a `GeoJsonLayer` object:
+
+_Before_
 ```java
 GeoJsonLayer layer = new GeoJsonLayer(
     map, 
@@ -63,7 +95,7 @@ GeoJsonLayer layer = new GeoJsonLayer(
 );
 ```
 
-_After_:
+_After_
 ```kotlin
 val layer = GeoJsonLayer(
     map = map,
@@ -75,20 +107,22 @@ val layer = GeoJsonLayer(
 
 #### Destructuring Declarations
 
-_Before_:
+Destructuring properties of a `Point`:
+
+_Before_
 ```java
 Point point = new Point(1.0, 2.0);
 double x = point.x;
 double y = point.y;
 ```
 
-_After_:
+_After_
 ```kotlin
 val point = Point(1.0, 2.0)
 val (x, y) = point
 ```
 
-You can learn more by reading the [Javadoc].
+You can learn more about all the extensions provided by this library by reading the [reference documents][Javadoc].
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ Maps Android KTX
 ================
 
 ## Description
-This repository contains a set a of Kotlin extensions (KTX) for the [Maps SDK for Android Library][maps-sdk] and the [Utility][amu] libraries enabling you to write more concise, idiomatic Kotlin.
+This repository contains Kotlin extensions (KTX) for:
+1. The [Maps SDK for Android][maps-sdk]
+1. The [Utility library][amu]
+
+It enables you to write more concise, idiomatic Kotlin. Each set of extensions can be used independently or together.
 
 ## Requirements
 * API level 15+

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Discord](https://img.shields.io/discord/676948200904589322)](https://discord.gg/hYsWbmk)
 ![Apache-2.0](https://img.shields.io/badge/license-Apache-blue)
 
-Maps SDK for Android Utility KTX
-================================
+Maps Android KTX
+================
 
 ## Description
-This library contains a set of Kotlin extensions (KTX) for the [Maps SDK for Android Utility Library][amu] enabling you to write more concise, idiomatic Kotlin.
+This repository contains a set a of Kotlin extensions (KTX) for the [Maps SDK for Android Library][maps-sdk] and the [Utility][amu] libraries enabling you to write more concise, idiomatic Kotlin.
 
 ## Requirements
 * API level 15+
@@ -16,6 +16,11 @@ This library contains a set of Kotlin extensions (KTX) for the [Maps SDK for And
 
 ```groovy
 dependencies {
+
+    // KTX for the maps SDK library - Coming Soon
+    // implementation 'com.google.maps.android:maps-utils-ktx:<future-version>'
+
+    // KTX for the utility library
     implementation 'com.google.maps.android:maps-utils-ktx:0.2'
 }
 ```
@@ -93,10 +98,11 @@ You can also reach us on our [Discord channel].
 For more information, check out the detailed guide on the
 [Google Developers site][devsite-guide]. 
 
-[file an issue]: https://github.com/googlemaps/android-maps-ktx/issues/new/choose
-[pull request]: https://github.com/googlemaps/android-maps-ktx/compare
-[code of conduct]: CODE_OF_CONDUCT.md
 [Discord channel]: https://discord.gg/hYsWbmk
-[devsite-guide]: https://developers.google.com/maps/documentation/android-api/utility/
-[amu]: https://github.com/googlemaps/android-maps-utils
 [Javadoc]: https://googlemaps.github.io/android-maps-ktx/maps-utils-ktx/
+[amu]: https://github.com/googlemaps/android-maps-utils
+[code of conduct]: CODE_OF_CONDUCT.md
+[devsite-guide]: https://developers.google.com/maps/documentation/android-api/utility/
+[file an issue]: https://github.com/googlemaps/android-maps-ktx/issues/new/choose
+[maps-sdk]: https://developers.google.com/maps/documentation/android-sdk/intro
+[pull request]: https://github.com/googlemaps/android-maps-ktx/compare

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
             'junit'    : '1.1.1',
         ],
         'junit'            : '4.12',
-        'kotlin'           : '1.3.61',
+        'kotlin'           : '1.3.70',
         'kotlinxCoroutines': '1.3.2',
         'mockito'          : '3.0.0',
         'mockitoKotlin'    : '2.2.0',
@@ -60,7 +60,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.10.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Feb 27 13:47:44 PST 2020
+#Mon Mar 30 13:36:42 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
@@ -31,12 +31,12 @@ import com.google.android.gms.maps.model.Polyline
 import com.google.android.gms.maps.model.PolylineOptions
 import com.google.android.gms.maps.model.TileOverlay
 import com.google.android.gms.maps.model.TileOverlayOptions
-import com.google.maps.android.ktx.model.buildCircleOptions
-import com.google.maps.android.ktx.model.buildGroundOverlayOptions
-import com.google.maps.android.ktx.model.buildMarkerOptions
-import com.google.maps.android.ktx.model.buildPolygonOptions
-import com.google.maps.android.ktx.model.buildPolylineOptions
-import com.google.maps.android.ktx.model.buildTileOverlayOptions
+import com.google.maps.android.ktx.model.circleOptions
+import com.google.maps.android.ktx.model.groundOverlayOptions
+import com.google.maps.android.ktx.model.markerOptions
+import com.google.maps.android.ktx.model.polygonOptions
+import com.google.maps.android.ktx.model.polylineOptions
+import com.google.maps.android.ktx.model.tileOverlayOptions
 
 /**
  * Builds a new [GoogleMapOptions] using the provided [optionsActions].
@@ -55,7 +55,7 @@ inline fun buildGoogleMapOptions(optionsActions: GoogleMapOptions.() -> Unit): G
  */
 inline fun GoogleMap.addCircle(optionsActions: CircleOptions.() -> Unit): Circle =
     this.addCircle(
-        buildCircleOptions(optionsActions)
+        circleOptions(optionsActions)
     )
 
 /**
@@ -68,7 +68,7 @@ inline fun GoogleMap.addGroundOverlay(
     optionsActions: GroundOverlayOptions.() -> Unit
 ): GroundOverlay =
     this.addGroundOverlay(
-        buildGroundOverlayOptions(optionsActions)
+        groundOverlayOptions(optionsActions)
     )
 
 /**
@@ -78,7 +78,7 @@ inline fun GoogleMap.addGroundOverlay(
  */
 inline fun GoogleMap.addMarker(optionsActions: MarkerOptions.() -> Unit): Marker =
     this.addMarker(
-        buildMarkerOptions(optionsActions)
+        markerOptions(optionsActions)
     )
 
 /**
@@ -88,7 +88,7 @@ inline fun GoogleMap.addMarker(optionsActions: MarkerOptions.() -> Unit): Marker
  */
 inline fun GoogleMap.addPolygon(optionsActions: PolygonOptions.() -> Unit): Polygon =
     this.addPolygon(
-        buildPolygonOptions(optionsActions)
+        polygonOptions(optionsActions)
     )
 
 /**
@@ -98,7 +98,7 @@ inline fun GoogleMap.addPolygon(optionsActions: PolygonOptions.() -> Unit): Poly
  */
 inline fun GoogleMap.addPolyline(optionsActions: PolylineOptions.() -> Unit): Polyline =
     this.addPolyline(
-        buildPolylineOptions(optionsActions)
+        polylineOptions(optionsActions)
     )
 
 /**
@@ -109,5 +109,5 @@ inline fun GoogleMap.addPolyline(optionsActions: PolylineOptions.() -> Unit): Po
  */
 inline fun GoogleMap.addTileOverlay(optionsActions: TileOverlayOptions.() -> Unit): TileOverlay =
     this.addTileOverlay(
-        buildTileOverlayOptions(optionsActions)
+        tileOverlayOptions(optionsActions)
     )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
@@ -64,9 +64,7 @@ inline fun GoogleMap.addCircle(optionsActions: CircleOptions.() -> Unit): Circle
  *
  * @return the added [Circle]
  */
-inline fun GoogleMap.addGroundOverlay(
-    optionsActions: GroundOverlayOptions.() -> Unit
-): GroundOverlay =
+inline fun GoogleMap.addGroundOverlay(optionsActions: GroundOverlayOptions.() -> Unit): GroundOverlay =
     this.addGroundOverlay(
         groundOverlayOptions(optionsActions)
     )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
@@ -20,6 +20,8 @@ package com.google.maps.android.ktx
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.CircleOptions
+import com.google.android.gms.maps.model.GroundOverlay
+import com.google.android.gms.maps.model.GroundOverlayOptions
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.gms.maps.model.Polygon
@@ -27,13 +29,13 @@ import com.google.android.gms.maps.model.PolygonOptions
 import com.google.android.gms.maps.model.Polyline
 import com.google.android.gms.maps.model.PolylineOptions
 import com.google.maps.android.ktx.model.buildCircleOptions
+import com.google.maps.android.ktx.model.buildGroundOverlayOptions
 import com.google.maps.android.ktx.model.buildMarkerOptions
 import com.google.maps.android.ktx.model.buildPolygonOptions
 import com.google.maps.android.ktx.model.buildPolylineOptions
 
 /**
- * Adds a [Circle] to this [GoogleMap] using the [CircleOptions] specified in the [optionsActions]
- * lambda.
+ * Adds a [Circle] to this [GoogleMap] using the function literal with receiver [optionsActions].
  *
  * @return the added [Circle]
  */
@@ -41,9 +43,22 @@ inline fun GoogleMap.addCircle(optionsActions: CircleOptions.() -> Unit): Circle
     this.addCircle(
         buildCircleOptions(optionsActions)
     )
+
 /**
- * Adds a [Marker] to this [GoogleMap] using the [MarkerOptions] specified in the [optionsActions]
- * lambda.
+ * Adds a [GroundOverlay] to this [GoogleMap] using the function literal with receiver
+ * [optionsActions].
+ *
+ * @return the added [Circle]
+ */
+inline fun GoogleMap.addGroundOverlay(
+    optionsActions: GroundOverlayOptions.() -> Unit
+): GroundOverlay =
+    this.addGroundOverlay(
+        buildGroundOverlayOptions(optionsActions)
+    )
+
+/**
+ * Adds a [Marker] to this [GoogleMap] using the function literal with receiver [optionsActions].
  *
  * @return the added [Marker]
  */
@@ -53,8 +68,7 @@ inline fun GoogleMap.addMarker(optionsActions: MarkerOptions.() -> Unit): Marker
     )
 
 /**
- * Adds a [Polygon] to this [GoogleMap] using the [PolygonOptions] specified in the [optionsActions]
- * lambda.
+ * Adds a [Polygon] to this [GoogleMap] using the function literal with receiver [optionsActions].
  *
  * @return the added [Polygon]
  */
@@ -64,8 +78,7 @@ inline fun GoogleMap.addPolygon(optionsActions: PolygonOptions.() -> Unit): Poly
     )
 
 /**
- * Adds a [Polyline] to this [GoogleMap] using the [PolylineOptions] specified in the
- * [optionsActions] lambda.
+ * Adds a [Polyline] to this [GoogleMap] using the function literal with receiver [optionsActions].
  *
  * @return the added [Polyline]
  */

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
@@ -24,9 +24,12 @@ import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.gms.maps.model.Polygon
 import com.google.android.gms.maps.model.PolygonOptions
+import com.google.android.gms.maps.model.Polyline
+import com.google.android.gms.maps.model.PolylineOptions
 import com.google.maps.android.ktx.model.buildCircleOptions
 import com.google.maps.android.ktx.model.buildMarkerOptions
 import com.google.maps.android.ktx.model.buildPolygonOptions
+import com.google.maps.android.ktx.model.buildPolylineOptions
 
 /**
  * Adds a [Circle] to this [GoogleMap] using the [CircleOptions] specified in the [optionsActions]
@@ -58,4 +61,15 @@ inline fun GoogleMap.addMarker(optionsActions: MarkerOptions.() -> Unit): Marker
 inline fun GoogleMap.addPolygon(optionsActions: PolygonOptions.() -> Unit): Polygon =
     this.addPolygon(
         buildPolygonOptions(optionsActions)
+    )
+
+/**
+ * Adds a [Polyline] to this [GoogleMap] using the [PolylineOptions] specified in the
+ * [optionsActions] lambda.
+ *
+ * @return the added [Polyline]
+ */
+inline fun GoogleMap.addPolyline(optionsActions: PolylineOptions.() -> Unit): Polyline =
+    this.addPolyline(
+        buildPolylineOptions(optionsActions)
     )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
@@ -18,13 +18,26 @@
 package com.google.maps.android.ktx
 
 import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.model.Circle
+import com.google.android.gms.maps.model.CircleOptions
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.gms.maps.model.Polygon
 import com.google.android.gms.maps.model.PolygonOptions
+import com.google.maps.android.ktx.model.buildCircleOptions
 import com.google.maps.android.ktx.model.buildMarkerOptions
 import com.google.maps.android.ktx.model.buildPolygonOptions
 
+/**
+ * Adds a [Circle] to this [GoogleMap] using the [CircleOptions] specified in the [optionsActions]
+ * lambda.
+ *
+ * @return the added [Circle]
+ */
+inline fun GoogleMap.addCircle(optionsActions: CircleOptions.() -> Unit): Circle =
+    this.addCircle(
+        buildCircleOptions(optionsActions)
+    )
 /**
  * Adds a [Marker] to this [GoogleMap] using the [MarkerOptions] specified in the [optionsActions]
  * lambda.

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
@@ -28,11 +28,14 @@ import com.google.android.gms.maps.model.Polygon
 import com.google.android.gms.maps.model.PolygonOptions
 import com.google.android.gms.maps.model.Polyline
 import com.google.android.gms.maps.model.PolylineOptions
+import com.google.android.gms.maps.model.TileOverlay
+import com.google.android.gms.maps.model.TileOverlayOptions
 import com.google.maps.android.ktx.model.buildCircleOptions
 import com.google.maps.android.ktx.model.buildGroundOverlayOptions
 import com.google.maps.android.ktx.model.buildMarkerOptions
 import com.google.maps.android.ktx.model.buildPolygonOptions
 import com.google.maps.android.ktx.model.buildPolylineOptions
+import com.google.maps.android.ktx.model.buildTileOverlayOptions
 
 /**
  * Adds a [Circle] to this [GoogleMap] using the function literal with receiver [optionsActions].
@@ -85,4 +88,15 @@ inline fun GoogleMap.addPolygon(optionsActions: PolygonOptions.() -> Unit): Poly
 inline fun GoogleMap.addPolyline(optionsActions: PolylineOptions.() -> Unit): Polyline =
     this.addPolyline(
         buildPolylineOptions(optionsActions)
+    )
+
+/**
+ * Adds a [TileOverlay] to this [GoogleMap] using the function literal with receiver
+ * [optionsActions].
+ *
+ * @return the added [Polyline]
+ */
+inline fun GoogleMap.addTileOverlay(optionsActions: TileOverlayOptions.() -> Unit): TileOverlay =
+    this.addTileOverlay(
+        buildTileOverlayOptions(optionsActions)
     )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
@@ -18,6 +18,7 @@
 package com.google.maps.android.ktx
 
 import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.GoogleMapOptions
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.CircleOptions
 import com.google.android.gms.maps.model.GroundOverlay
@@ -36,6 +37,16 @@ import com.google.maps.android.ktx.model.buildMarkerOptions
 import com.google.maps.android.ktx.model.buildPolygonOptions
 import com.google.maps.android.ktx.model.buildPolylineOptions
 import com.google.maps.android.ktx.model.buildTileOverlayOptions
+
+/**
+ * Builds a new [GoogleMapOptions] using the provided [optionsActions].
+ *
+ * @return the constructed [GoogleMapOptions]
+ */
+inline fun buildGoogleMapOptions(optionsActions: GoogleMapOptions.() -> Unit): GoogleMapOptions =
+    GoogleMapOptions().apply(
+        optionsActions
+    )
 
 /**
  * Adds a [Circle] to this [GoogleMap] using the function literal with receiver [optionsActions].

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx
+
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.model.Marker
+import com.google.android.gms.maps.model.MarkerOptions
+import com.google.android.gms.maps.model.Polygon
+import com.google.android.gms.maps.model.PolygonOptions
+import com.google.maps.android.ktx.model.buildMarkerOptions
+import com.google.maps.android.ktx.model.buildPolygonOptions
+
+/**
+ * Adds a [Marker] to this [GoogleMap] using the [MarkerOptions] specified in the [optionsActions]
+ * lambda.
+ *
+ * @return the added [Marker]
+ */
+inline fun GoogleMap.addMarker(optionsActions: MarkerOptions.() -> Unit): Marker =
+    this.addMarker(
+        buildMarkerOptions(optionsActions)
+    )
+
+/**
+ * Adds a [Polygon] to this [GoogleMap] using the [PolygonOptions] specified in the [optionsActions]
+ * lambda.
+ *
+ * @return the added [Polygon]
+ */
+inline fun GoogleMap.addPolygon(optionsActions: PolygonOptions.() -> Unit): Polygon =
+    this.addPolygon(
+        buildPolygonOptions(optionsActions)
+    )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/MapFragment.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/MapFragment.kt
@@ -18,18 +18,17 @@
 package com.google.maps.android.ktx
 
 import com.google.android.gms.maps.GoogleMap
-import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.MapFragment
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 /**
- * A suspending function that provides an instance of a [GoogleMap] from this [SupportMapFragment].
- * This is an alternative to using [SupportMapFragment.getMapAsync] by using coroutines to obtain
- * a [GoogleMap].
+ * A suspending function that provides an instance of a [GoogleMap] from this [MapFragment].
+ * This is an alternative to [MapFragment.getMapAsync] by using coroutines to obtain a [GoogleMap].
  *
  * @return the [GoogleMap] instance
  */
-suspend inline fun SupportMapFragment.awaitMap(): GoogleMap =
+suspend inline fun MapFragment.awaitMap(): GoogleMap =
     suspendCoroutine { continuation ->
         getMapAsync {
             continuation.resume(it)

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/MapFragment.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/MapFragment.kt
@@ -22,12 +22,16 @@ import com.google.android.gms.maps.MapFragment
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
+@RequiresOptIn
+annotation class MapsExperimentalFeature
+
 /**
  * A suspending function that provides an instance of a [GoogleMap] from this [MapFragment].
  * This is an alternative to [MapFragment.getMapAsync] by using coroutines to obtain a [GoogleMap].
  *
  * @return the [GoogleMap] instance
  */
+@MapsExperimentalFeature
 suspend inline fun MapFragment.awaitMap(): GoogleMap =
     suspendCoroutine { continuation ->
         getMapAsync {

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/StreetViewPanoramaFragment.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/StreetViewPanoramaFragment.kt
@@ -17,21 +17,22 @@
 
 package com.google.maps.android.ktx
 
-import com.google.android.gms.maps.GoogleMap
-import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.StreetViewPanorama
+import com.google.android.gms.maps.StreetViewPanoramaFragment
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 /**
- * A suspending function that provides an instance of a [GoogleMap] from this [SupportMapFragment].
- * This is an alternative to using [SupportMapFragment.getMapAsync] by using coroutines to obtain
- * a [GoogleMap].
+ * A suspending function that provides an instance of a [StreetViewPanorama] from this
+ * [StreetViewPanoramaFragment]. This is an alternative to using
+ * [StreetViewPanoramaFragment.getStreetViewPanoramaAsync] by using coroutines to obtain a
+ * [StreetViewPanorama].
  *
- * @return the [GoogleMap] instance
+ * @return the [StreetViewPanorama]
  */
-suspend inline fun SupportMapFragment.awaitMap(): GoogleMap =
+suspend inline fun StreetViewPanoramaFragment.awaitStreetViewPanorama(): StreetViewPanorama =
     suspendCoroutine { continuation ->
-        getMapAsync {
+        getStreetViewPanoramaAsync {
             continuation.resume(it)
         }
     }

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/StreetViewPanoramaFragment.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/StreetViewPanoramaFragment.kt
@@ -30,6 +30,7 @@ import kotlin.coroutines.suspendCoroutine
  *
  * @return the [StreetViewPanorama]
  */
+@MapsExperimentalFeature
 suspend inline fun StreetViewPanoramaFragment.awaitStreetViewPanorama(): StreetViewPanorama =
     suspendCoroutine { continuation ->
         getStreetViewPanoramaAsync {

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/SupportMapFragment.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/SupportMapFragment.kt
@@ -29,6 +29,7 @@ import kotlin.coroutines.suspendCoroutine
  *
  * @return the [GoogleMap] instance
  */
+@MapsExperimentalFeature
 suspend inline fun SupportMapFragment.awaitMap(): GoogleMap =
     suspendCoroutine { continuation ->
         getMapAsync {

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/SupportStreetViewPanoramaFragment.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/SupportStreetViewPanoramaFragment.kt
@@ -30,6 +30,7 @@ import kotlin.coroutines.suspendCoroutine
  *
  * @return the [StreetViewPanorama]
  */
+@MapsExperimentalFeature
 suspend inline fun SupportStreetViewPanoramaFragment.awaitStreetViewPanorama(): StreetViewPanorama =
     suspendCoroutine { continuation ->
         getStreetViewPanoramaAsync {

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/SupportStreetViewPanoramaFragment.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/SupportStreetViewPanoramaFragment.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx
+
+import com.google.android.gms.maps.StreetViewPanorama
+import com.google.android.gms.maps.SupportStreetViewPanoramaFragment
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * A suspending function that provides an instance of a [StreetViewPanorama] from this
+ * [SupportStreetViewPanoramaFragment]. This is an alternative to using
+ * [SupportStreetViewPanoramaFragment.getStreetViewPanoramaAsync] by using coroutines to obtain a
+ * [StreetViewPanorama].
+ *
+ * @return the [StreetViewPanorama]
+ */
+suspend inline fun SupportStreetViewPanoramaFragment.awaitStreetViewPanorama(): StreetViewPanorama =
+    suspendCoroutine { continuation ->
+        getStreetViewPanoramaAsync {
+            continuation.resume(it)
+        }
+    }

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/CameraPosition.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/CameraPosition.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import com.google.android.gms.maps.model.CameraPosition
+
+/**
+ * Builds a new [CameraPosition] using the provided [optionsActions]. Using this removes the need
+ * to construct a [CameraPosition.Builder] object.
+ *
+ * @return the constructed [CameraPosition]
+ */
+inline fun cameraPosition(optionsActions: CameraPosition.Builder.() -> Unit): CameraPosition =
+    CameraPosition.Builder().apply(optionsActions).build()

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/CircleOptions.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/CircleOptions.kt
@@ -24,7 +24,7 @@ import com.google.android.gms.maps.model.CircleOptions
  *
  * @return the constructed [CircleOptions]
  */
-inline fun buildCircleOptions(optionsActions: CircleOptions.() -> Unit): CircleOptions =
+inline fun circleOptions(optionsActions: CircleOptions.() -> Unit): CircleOptions =
     CircleOptions().apply(
         optionsActions
     )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/CircleOptions.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/CircleOptions.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import com.google.android.gms.maps.model.CircleOptions
+
+/**
+ * Builds a new [CircleOptions] using the provided [optionsActions].
+ *
+ * @return the constructed [CircleOptions]
+ */
+inline fun buildCircleOptions(optionsActions: CircleOptions.() -> Unit): CircleOptions =
+    CircleOptions().apply(
+        optionsActions
+    )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/GroundOverlayOptions.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/GroundOverlayOptions.kt
@@ -24,7 +24,7 @@ import com.google.android.gms.maps.model.GroundOverlayOptions
  *
  * @return the constructed [GroundOverlayOptions]
  */
-inline fun buildGroundOverlayOptions(optionsActions: GroundOverlayOptions.() -> Unit): GroundOverlayOptions =
+inline fun groundOverlayOptions(optionsActions: GroundOverlayOptions.() -> Unit): GroundOverlayOptions =
     GroundOverlayOptions().apply(
         optionsActions
     )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/GroundOverlayOptions.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/GroundOverlayOptions.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import com.google.android.gms.maps.model.GroundOverlayOptions
+
+/**
+ * Builds a new [GroundOverlayOptions] using the provided [optionsActions].
+ *
+ * @return the constructed [GroundOverlayOptions]
+ */
+inline fun buildGroundOverlayOptions(optionsActions: GroundOverlayOptions.() -> Unit): GroundOverlayOptions =
+    GroundOverlayOptions().apply(
+        optionsActions
+    )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/MarkerOptions.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/MarkerOptions.kt
@@ -24,7 +24,7 @@ import com.google.android.gms.maps.model.MarkerOptions
  *
  * @return the constructed [MarkerOptions]
  */
-inline fun buildMarkerOptions(optionsActions: MarkerOptions.() -> Unit): MarkerOptions =
+inline fun markerOptions(optionsActions: MarkerOptions.() -> Unit): MarkerOptions =
     MarkerOptions().apply(
         optionsActions
     )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/MarkerOptions.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/MarkerOptions.kt
@@ -15,20 +15,16 @@
  *
  */
 
-package com.google.maps.android.ktx
+package com.google.maps.android.ktx.model
 
-import com.google.android.gms.maps.GoogleMap
-import com.google.android.gms.maps.SupportMapFragment
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
+import com.google.android.gms.maps.model.MarkerOptions
 
 /**
- * A suspending functioning that provides an instance of a [GoogleMap] from this
- * [SupportMapFragment].
+ * Builds a new [MarkerOptions] using the provided [optionsActions].
+ *
+ * @return the constructed [MarkerOptions]
  */
-suspend inline fun SupportMapFragment.awaitMap(): GoogleMap =
-    suspendCoroutine { continuation ->
-        getMapAsync {
-            continuation.resume(it)
-        }
-    }
+inline fun buildMarkerOptions(optionsActions: MarkerOptions.() -> Unit): MarkerOptions =
+    MarkerOptions().apply(
+        optionsActions
+    )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/PolygonOptions.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/PolygonOptions.kt
@@ -15,14 +15,17 @@
  *
  */
 
-package com.google.maps.android.ktx
+package com.google.maps.android.ktx.model
 
 import com.google.android.gms.maps.model.PolygonOptions
 
 /**
  * Builds a new [PolygonOptions] using the provided [optionsActions].
- * CORE
+ *
+ * @return the [PolygonOptions]
  */
 inline fun buildPolygonOptions(optionsActions: PolygonOptions.() -> Unit): PolygonOptions =
-    PolygonOptions().apply(optionsActions)
+    PolygonOptions().apply(
+        optionsActions
+    )
 

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/PolygonOptions.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/PolygonOptions.kt
@@ -24,7 +24,7 @@ import com.google.android.gms.maps.model.PolygonOptions
  *
  * @return the [PolygonOptions]
  */
-inline fun buildPolygonOptions(optionsActions: PolygonOptions.() -> Unit): PolygonOptions =
+inline fun polygonOptions(optionsActions: PolygonOptions.() -> Unit): PolygonOptions =
     PolygonOptions().apply(
         optionsActions
     )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/PolylineOptions.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/PolylineOptions.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import com.google.android.gms.maps.model.PolylineOptions
+
+/**
+ * Builds a new [PolylineOptions] using the provided [optionsActions].
+ *
+ * @return the constructed [PolylineOptions]
+ */
+inline fun buildPolylineOptions(optionsActions: PolylineOptions.() -> Unit): PolylineOptions =
+    PolylineOptions().apply(
+        optionsActions
+    )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/PolylineOptions.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/PolylineOptions.kt
@@ -24,7 +24,7 @@ import com.google.android.gms.maps.model.PolylineOptions
  *
  * @return the constructed [PolylineOptions]
  */
-inline fun buildPolylineOptions(optionsActions: PolylineOptions.() -> Unit): PolylineOptions =
+inline fun polylineOptions(optionsActions: PolylineOptions.() -> Unit): PolylineOptions =
     PolylineOptions().apply(
         optionsActions
     )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/StreetViewPanoramaCamera.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/StreetViewPanoramaCamera.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import com.google.android.gms.maps.model.StreetViewPanoramaCamera
+
+/**
+ * Builds a new [StreetViewPanoramaCamera] using the provided [optionsActions]. Using this removes
+ * the need to construct a [StreetViewPanoramaCamera.Builder] object.
+ *
+ * @return the constructed [StreetViewPanoramaCamera]
+ */
+inline fun streetViewPanoramaCamera(
+    optionsActions: StreetViewPanoramaCamera.Builder.() -> Unit
+): StreetViewPanoramaCamera =
+    StreetViewPanoramaCamera.Builder().apply(
+        optionsActions
+    ).build()

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/StreetViewPanoramaOrientation.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/StreetViewPanoramaOrientation.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import com.google.android.gms.maps.model.StreetViewPanoramaOrientation
+
+/**
+ * Builds a new [StreetViewPanoramaOrientation] using the provided [optionsActions]. Using this
+ * removes * the need to construct a [StreetViewPanoramaOrientation.Builder] object.
+ *
+ * @return the constructed [StreetViewPanoramaOrientation]
+ */
+inline fun streetViewPanoramaOrientation(
+    optionsActions: StreetViewPanoramaOrientation.Builder.() -> Unit
+): StreetViewPanoramaOrientation =
+    StreetViewPanoramaOrientation.Builder().apply(
+        optionsActions
+    ).build()

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/TileOverlayOptioms.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/TileOverlayOptioms.kt
@@ -24,7 +24,7 @@ import com.google.android.gms.maps.model.TileOverlayOptions
  *
  * @return the constructed [TileOverlayOptions]
  */
-inline fun buildTileOverlayOptions(optionsActions: TileOverlayOptions.() -> Unit): TileOverlayOptions =
+inline fun tileOverlayOptions(optionsActions: TileOverlayOptions.() -> Unit): TileOverlayOptions =
     TileOverlayOptions().apply(
         optionsActions
     )

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/model/TileOverlayOptioms.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/model/TileOverlayOptioms.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import com.google.android.gms.maps.model.TileOverlayOptions
+
+/**
+ * Builds a new [TileOverlayOptions] using the provided [optionsActions].
+ *
+ * @return the constructed [TileOverlayOptions]
+ */
+inline fun buildTileOverlayOptions(optionsActions: TileOverlayOptions.() -> Unit): TileOverlayOptions =
+    TileOverlayOptions().apply(
+        optionsActions
+    )

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/CameraPositionTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/CameraPositionTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import com.google.android.gms.maps.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CameraPositionTest {
+
+    @Test
+    fun testBuilder() {
+        val cameraPosition = cameraPosition {
+            bearing(1f)
+            target(LatLng(1.0, 2.0))
+            tilt(1f)
+            zoom(12f)
+        }
+        assertEquals(1f, cameraPosition.bearing, 1e-6f)
+        assertEquals(LatLng(1.0, 2.0), cameraPosition.target)
+        assertEquals(1f, cameraPosition.tilt, 1e-6f)
+        assertEquals(12f, cameraPosition.zoom, 1e-6f)
+    }
+}

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/CircleOptionsTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/CircleOptionsTest.kt
@@ -23,25 +23,27 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class MarkerOptionsTest {
+class CircleOptionsTest {
 
     @Test
     fun testBuilder() {
-        val markerOptions = buildMarkerOptions {
-            position(LatLng(1.0, 2.0))
-            alpha(0.5f)
-            draggable(false)
-            flat(true)
-            title("Test")
-            snippet("Snippet")
+        val circleOptions = buildCircleOptions {
+            center(LatLng(0.0, 0.0))
+            clickable(true)
+            fillColor(0)
+            radius(1.23)
+            strokeColor(1)
+            strokeWidth(2f)
             visible(true)
+            zIndex(1f)
         }
-        assertEquals(LatLng(1.0, 2.0), markerOptions.position)
-        assertEquals(0.5f, markerOptions.alpha, 1e-6f)
-        assertFalse(markerOptions.isDraggable)
-        assertTrue(markerOptions.isFlat)
-        assertEquals("Test", markerOptions.title)
-        assertEquals("Snippet", markerOptions.snippet)
-        assertTrue(markerOptions.isVisible)
+        assertEquals(LatLng(0.0, 0.0), circleOptions.center)
+        assertTrue(circleOptions.isClickable)
+        assertEquals(0, circleOptions.fillColor)
+        assertEquals(1.23, circleOptions.radius, 1e-6)
+        assertEquals(1, circleOptions.strokeColor)
+        assertEquals(2f, circleOptions.strokeWidth)
+        assertTrue(circleOptions.isVisible)
+        assertEquals(1f, circleOptions.zIndex, 1e-6f)
     }
 }

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/CircleOptionsTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/CircleOptionsTest.kt
@@ -19,7 +19,6 @@ package com.google.maps.android.ktx.model
 
 import com.google.android.gms.maps.model.LatLng
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -27,7 +26,7 @@ class CircleOptionsTest {
 
     @Test
     fun testBuilder() {
-        val circleOptions = buildCircleOptions {
+        val circleOptions = circleOptions {
             center(LatLng(0.0, 0.0))
             clickable(true)
             fillColor(0)

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/GroundOverlayOptionsTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/GroundOverlayOptionsTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import com.google.android.gms.maps.model.BitmapDescriptor
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GroundOverlayOptionsTest {
+
+    @Test
+    fun testBuilder() {
+        val descriptor: BitmapDescriptor = mock()
+        val groundOverlayOptions = buildGroundOverlayOptions {
+            image(descriptor)
+            bearing(1f)
+            clickable(true)
+            transparency(0.5f)
+            visible(true)
+        }
+        assertEquals(descriptor, groundOverlayOptions.image)
+        assertEquals(1f, groundOverlayOptions.bearing, 1e-6f)
+        assertTrue(groundOverlayOptions.isClickable)
+        assertEquals(0.5f, groundOverlayOptions.transparency, 1e-6f)
+        assertTrue(groundOverlayOptions.isVisible)
+    }
+}

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/GroundOverlayOptionsTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/GroundOverlayOptionsTest.kt
@@ -28,7 +28,7 @@ class GroundOverlayOptionsTest {
     @Test
     fun testBuilder() {
         val descriptor: BitmapDescriptor = mock()
-        val groundOverlayOptions = buildGroundOverlayOptions {
+        val groundOverlayOptions = groundOverlayOptions {
             image(descriptor)
             bearing(1f)
             clickable(true)

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/MarkerOptionsTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/MarkerOptionsTest.kt
@@ -27,7 +27,7 @@ class MarkerOptionsTest {
 
     @Test
     fun testBuilder() {
-        val markerOptions = buildMarkerOptions {
+        val markerOptions = markerOptions {
             position(LatLng(1.0, 2.0))
             alpha(0.5f)
             draggable(false)

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/MarkerOptionsTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/MarkerOptionsTest.kt
@@ -15,24 +15,31 @@
  *
  */
 
-package com.google.maps.android.ktx
+package com.google.maps.android.ktx.model
 
-import android.graphics.Color
 import com.google.android.gms.maps.model.LatLng
-import org.junit.Assert.assertEquals
+import org.junit.Assert.*
 import org.junit.Test
 
-class PolygonOptionsTest {
+class MarkerOptionsTest {
+
     @Test
     fun testBuilder() {
-        val polygonOptions =
-            com.google.maps.android.ktx.buildPolygonOptions {
-                strokeWidth(1.0f)
-                strokeColor(Color.BLACK)
-                add(LatLng(0.0, 0.0))
-            }
-        assertEquals(1.0f, polygonOptions.strokeWidth)
-        assertEquals(Color.BLACK, polygonOptions.strokeColor)
-        assertEquals(listOf(LatLng(0.0, 0.0)), polygonOptions.points)
+        val markerOptions = buildMarkerOptions {
+            position(LatLng(1.0, 2.0))
+            alpha(0.5f)
+            draggable(false)
+            flat(true)
+            title("Test")
+            snippet("Snippet")
+            visible(true)
+        }
+        assertEquals(LatLng(1.0, 2.0), markerOptions.position)
+        assertEquals(0.5f, markerOptions.alpha, 1e-6f)
+        assertFalse(markerOptions.isDraggable)
+        assertTrue(markerOptions.isFlat)
+        assertEquals("Test", markerOptions.title)
+        assertEquals("Snippet", markerOptions.snippet)
+        assertTrue(markerOptions.isVisible)
     }
 }

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/PolygonOptionsTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/PolygonOptionsTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import android.graphics.Color
+import com.google.android.gms.maps.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PolygonOptionsTest {
+    @Test
+    fun testBuilder() {
+        val polygonOptions =
+            buildPolygonOptions {
+                strokeWidth(1.0f)
+                strokeColor(Color.BLACK)
+                add(LatLng(0.0, 0.0))
+            }
+        assertEquals(1.0f, polygonOptions.strokeWidth, 1e-6f)
+        assertEquals(Color.BLACK, polygonOptions.strokeColor)
+        assertEquals(listOf(LatLng(0.0, 0.0)), polygonOptions.points)
+    }
+}

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/PolygonOptionsTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/PolygonOptionsTest.kt
@@ -26,7 +26,7 @@ class PolygonOptionsTest {
     @Test
     fun testBuilder() {
         val polygonOptions =
-            buildPolygonOptions {
+            polygonOptions {
                 strokeWidth(1.0f)
                 strokeColor(Color.BLACK)
                 add(LatLng(0.0, 0.0))

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/PolygonOptionsTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/PolygonOptionsTest.kt
@@ -29,10 +29,10 @@ class PolygonOptionsTest {
             polygonOptions {
                 strokeWidth(1.0f)
                 strokeColor(Color.BLACK)
-                add(LatLng(0.0, 0.0))
+                add(LatLng(1.0, 2.0))
             }
         assertEquals(1.0f, polygonOptions.strokeWidth, 1e-6f)
         assertEquals(Color.BLACK, polygonOptions.strokeColor)
-        assertEquals(listOf(LatLng(0.0, 0.0)), polygonOptions.points)
+        assertEquals(listOf(LatLng(1.0, 2.0)), polygonOptions.points)
     }
 }

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/PolylineOptionsTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/PolylineOptionsTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import com.google.android.gms.maps.model.LatLng
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PolylineOptionsTest {
+
+    @Test
+    fun testBuilder() {
+        val polylineOptions = buildPolylineOptions {
+            add(LatLng(1.0, 2.0))
+            clickable(true)
+            color(0)
+            geodesic(true)
+            width(1f)
+        }
+        assertEquals(listOf(LatLng(1.0, 2.0)), polylineOptions.points)
+        assertTrue(polylineOptions.isClickable)
+        assertEquals(0, polylineOptions.color)
+        assertTrue(polylineOptions.isGeodesic)
+        assertEquals(1f, polylineOptions.width, 1e-6f)
+    }
+}

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/PolylineOptionsTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/PolylineOptionsTest.kt
@@ -26,7 +26,7 @@ class PolylineOptionsTest {
 
     @Test
     fun testBuilder() {
-        val polylineOptions = buildPolylineOptions {
+        val polylineOptions = polylineOptions {
             add(LatLng(1.0, 2.0))
             clickable(true)
             color(0)

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/StreetViewPanoramaCameraTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/StreetViewPanoramaCameraTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StreetViewPanoramaCameraTest {
+
+    @Test
+    fun `test that StreetViewPanoramaCamera is constructed`() {
+        val camera = streetViewPanoramaCamera {
+            bearing(1f)
+            tilt(20f)
+            zoom(2f)
+        }
+        assertEquals(1f, camera.bearing, 1e-6f)
+        assertEquals(20f, camera.tilt, 1e-6f)
+        assertEquals(2f, camera.zoom, 1e-6f)
+    }
+}

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/StreetViewPanoramaOrientationTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/StreetViewPanoramaOrientationTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StreetViewPanoramaOrientationTest {
+
+    @Test
+    fun `test that StreetViewPanoramaOrientation is constructed`() {
+        val orientation = streetViewPanoramaOrientation {
+            bearing(1f)
+            tilt(20f)
+        }
+        assertEquals(1f, orientation.bearing, 1e-6f)
+        assertEquals(20f, orientation.tilt, 1e-6f)
+    }
+}

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/TileOverlayOptionsTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/TileOverlayOptionsTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.model
+
+import com.google.android.gms.maps.model.TileProvider
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TileOverlayOptionsTest {
+
+    @Test
+    fun testBuilder() {
+        val tileOverlayOptions = buildTileOverlayOptions {
+            fadeIn(true)
+            transparency(0.5f)
+            visible(false)
+            zIndex(1f)
+        }
+        assertTrue(tileOverlayOptions.fadeIn)
+        assertFalse(tileOverlayOptions.isVisible)
+        assertEquals(0.5f, tileOverlayOptions.transparency, 1e-6f)
+        assertEquals(1f, tileOverlayOptions.zIndex, 1e-6f)
+    }
+}

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/model/TileOverlayOptionsTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/model/TileOverlayOptionsTest.kt
@@ -17,8 +17,6 @@
 
 package com.google.maps.android.ktx.model
 
-import com.google.android.gms.maps.model.TileProvider
-import com.nhaarman.mockitokotlin2.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -28,7 +26,7 @@ class TileOverlayOptionsTest {
 
     @Test
     fun testBuilder() {
-        val tileOverlayOptions = buildTileOverlayOptions {
+        val tileOverlayOptions = tileOverlayOptions {
             fadeIn(true)
             transparency(0.5f)
             visible(false)

--- a/maps-ktx/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/maps-ktx/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/maps-utils-ktx/src/test/java/com/google/maps/android/ktx/utils/PolygonTest.kt
+++ b/maps-utils-ktx/src/test/java/com/google/maps/android/ktx/utils/PolygonTest.kt
@@ -19,8 +19,6 @@ package com.google.maps.android.ktx.utils
 
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Polygon
-import com.google.maps.android.ktx.utils.contains
-import com.google.maps.android.ktx.utils.isOnEdge
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import org.junit.Assert.assertFalse


### PR DESCRIPTION
Adding Kotlin extensions to the Maps SDK for Android. This is the 1st pass after going through these reference docs: https://developers.google.com/maps/documentation/android-sdk/reference

@barbeau this is ready for review. Once merged, we can push this out on maven as a preview.