### PR TITLE
ci: Add unit test workflow

### DIFF
--- a/.github/workflows/ktx-docs.yml
+++ b/.github/workflows/ktx-docs.yml
@@ -6,6 +6,7 @@ on:
     tags: 
       - '*'
   repository_dispatch:
+      types: [gh-pages]
 
 jobs:
   gh-page-sync:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
   run-unit-test:
     runs-on: ubuntu-latest
 
+    steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout android-maps-ktx
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+# A workflow that runs tests on every new pull request
+name: Run unit tests
+
+on:
+  repository_dispatch:
+    types: [test]
+  pull_request:
+    branches: ['*']
+
+jobs:
+  run-unit-test:
+    runs-on: ubuntu-latest
+
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Checkout android-maps-ktx
+      uses: actions/checkout@v2
+
+    - name: Run tests
+      run: |
+        echo "Running unit tests"
+        ./gradlew check test jacocoTestReport -x lint --stacktrace
+
+        echo "Sending test results to CodeCov"
+        bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/googlemaps/android-maps-ktx.svg?branch=master)](https://travis-ci.org/googlemaps/android-maps-ktx)
+![Tests](https://github.com/googlemaps/android-maps-ktx/workflows/.github/workflows/test.yml/badge.svg)
 ![Beta](https://img.shields.io/badge/stability-beta-yellow)
 [![Discord](https://img.shields.io/discord/676948200904589322)](https://discord.gg/hYsWbmk)
 ![Apache-2.0](https://img.shields.io/badge/license-Apache-blue)


### PR DESCRIPTION
Consolidating CI to GitHub actions. 

Adding unit test workflow—will remove `.travis.yml` once the release workflow is migrated (will PR that next).