### PR TITLE
chore: Add GeoJsonLayer constructor alias for a resource ID

### DIFF
--- a/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/geojson/GeoJson.kt
+++ b/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/geojson/GeoJson.kt
@@ -18,6 +18,9 @@
 @file:Suppress("NOTHING_TO_INLINE")
 package com.google.maps.android.ktx.utils.geojson
 
+import android.content.Context
+import androidx.annotation.IntegerRes
+import androidx.annotation.RawRes
 import com.google.android.gms.maps.GoogleMap
 import com.google.maps.android.collections.GroundOverlayManager
 import com.google.maps.android.collections.MarkerManager
@@ -40,6 +43,28 @@ inline fun geoJsonLayer(
 ): GeoJsonLayer = GeoJsonLayer(
     map,
     geoJsonFile,
+    markerManager,
+    polygonManager,
+    polylineManager,
+    groundOverlayManager
+)
+
+/**
+ * Alias for the [GeoJsonLayer] constructor that provides Kotlin named parameters and default
+ * values.
+ */
+inline fun geoJsonLayer(
+    map: GoogleMap,
+    @RawRes resourceId: Int,
+    context: Context,
+    markerManager: MarkerManager? = null,
+    polygonManager: PolygonManager? = null,
+    polylineManager: PolylineManager? = null,
+    groundOverlayManager: GroundOverlayManager? = null
+): GeoJsonLayer = GeoJsonLayer(
+    map,
+    resourceId,
+    context,
     markerManager,
     polygonManager,
     polylineManager,


### PR DESCRIPTION
This is needed to construct an instance directly from an Android resource ID using named parameters. 

For example, this is how we construct GeoJsonLayers in the demo app (https://github.com/googlemaps/android-maps-ktx/pull/29).