### PR TITLE
feat: Add MarkerManager.Collection.addMarker helper

### DIFF
--- a/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/MarkerManager.kt
+++ b/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/MarkerManager.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.utils.collection
+
+import com.google.android.gms.maps.model.Marker
+import com.google.android.gms.maps.model.MarkerOptions
+import com.google.maps.android.collections.MarkerManager
+
+/**
+ * Adds a new [Marker] to this [MarkerManager.Collection] with the provided [optionsActions].
+ *
+ * @return the created [Marker]
+ */
+inline fun MarkerManager.Collection.addMarker(optionsActions: MarkerOptions.() -> Unit): Marker =
+    this.addMarker(
+        MarkerOptions().apply(optionsActions)
+    )


### PR DESCRIPTION
Adding a helper when adding a new marker to the marker collection. This is similar to the [GoogleMaps.addMarker](https://github.com/googlemaps/android-maps-ktx/blob/master/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt#L77) extension method. 

Something we can add to the demo once merged.

_Before_:
```kotlin
collection.addMarker(
    MarkerOptions()
        .position(LatLng(51.150000, -0.150032))
        .icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE))
        .title("Unclustered marker")
)
```

_After_:
```kotlin
collection.addMarker {
    position(LatLng(51.150000, -0.150032))
    icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE))
    title("Unclustered marker")
}
```
