### PR TITLE
docs: Add demo app instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ With this KTX library, you should be able to take advantage of several Kotlin la
 
 ### Demo App
 
-<img src="https://developers.google.com/maps/documentation/android-sdk/images/utility-multilayer.png" width="150" align=right>
+<img src="https://developers.google.com/maps/documentation/android-sdk/images/utility-multilayer.png" width="150" align=left>
 
 This repository includes a [demo app](app) that illustrates the use of this KTX library.
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ With this KTX library, you should be able to take advantage of several Kotlin la
 
 This repository includes a [demo app](app) that illustrates the use of this KTX library.
 
+<img src="https://developers.google.com/maps/documentation/android-sdk/images/utility-multilayer.png" width="150" align=right>
+
 To run the demo app, you'll to:
 
 1. [Get a Maps API key](https://developers.google.com/maps/documentation/android-sdk/get-api-key)
 1. Create a file in the `app` directory called `secure.properties` (this file should *NOT* be under version control to protect your API key)
 1. Add a single line to `app/secure.properties` that looks like `MAPS_API_KEY=YOUR_API_KEY`, where `YOUR_API_KEY` is the API key you obtained in the first step
 1. Build and run
-
-<img src="https://developers.google.com/maps/documentation/android-sdk/images/utility-multilayer.png" width="150" align=right>
 
 ### Maps SDK KTX
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ dependencies {
 
 With this KTX library, you should be able to take advantage of several Kotlin language features such as extension functions, named parameters and default arguments, destructuring declarations, and coroutines.
 
+### Demo App
+
+This repository includes a [demo app](app) that illustrates the use of this KTX library.
+
+To run the demo app, you'll to:
+
+1. [Get a Maps API key](https://developers.google.com/maps/documentation/android-sdk/get-api-key)
+1. Create a file in the `app` directory called `secure.properties` (this file should *NOT* be under version control to protect your API key)
+1. Add a single line to `app/secure.properties` that looks like `MAPS_API_KEY=YOUR_API_KEY`, where `YOUR_API_KEY` is the API key you obtained in the first step
+1. Build and run
+
+<img src="https://developers.google.com/maps/documentation/android-sdk/images/utility-multilayer.png" width="150" align=right>
+
 ### Maps SDK KTX
 
 #### Extension functions

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ With this KTX library, you should be able to take advantage of several Kotlin la
 
 ### Demo App
 
-This repository includes a [demo app](app) that illustrates the use of this KTX library.
-
 <img src="https://developers.google.com/maps/documentation/android-sdk/images/utility-multilayer.png" width="150" align=right>
+
+This repository includes a [demo app](app) that illustrates the use of this KTX library.
 
 To run the demo app, you'll to:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ With this KTX library, you should be able to take advantage of several Kotlin la
 
 This repository includes a [demo app](app) that illustrates the use of this KTX library.
 
-To run the demo app, you'll to:
+To run the demo app, you'll have to:
 
 1. [Get a Maps API key](https://developers.google.com/maps/documentation/android-sdk/get-api-key)
 1. Create a file in the `app` directory called `secure.properties` (this file should *NOT* be under version control to protect your API key)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ With this KTX library, you should be able to take advantage of several Kotlin la
 
 ### Demo App
 
-<img src="https://developers.google.com/maps/documentation/android-sdk/images/utility-multilayer.png" width="150" align=left>
+<img src="https://developers.google.com/maps/documentation/android-sdk/images/utility-multilayer.png" width="150" align=right>
 
 This repository includes a [demo app](app) that illustrates the use of this KTX library.
 


### PR DESCRIPTION
This PR adds setup instructions for the demo app to the README.

@arriolac I tried to add an app screenshot (re-using the screenshot from the [existing AMU docs multi-layer entry](https://developers.google.com/maps/documentation/android-sdk/utility)) to call attention to this section, but adding images in-line in markdown is always a little awkward. IMHO, it's not great, but it's not terrible. LMKWYT - I can remove it if you prefer.

Here's what it currently looks like:

![image](https://user-images.githubusercontent.com/928045/78934140-6822d980-7a78-11ea-8ff2-81254b5cfaca.png)


