### PR TITLE
build: Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,13 +1,19 @@
 version: 1
 update_configs:
     - package_manager: "java:gradle"
-      directory: "./library/"
+      directory: "./app/"
       update_schedule: "daily"
       commit_message:
           prefix: "chore(deps)"
 
     - package_manager: "java:gradle"
-      directory: "./demo/"
+      directory: "./maps-ktx/"
+      update_schedule: "daily"
+      commit_message:
+          prefix: "chore(deps)"
+
+    - package_manager: "java:gradle"
+      directory: "./maps-utils-ktx/"
       update_schedule: "daily"
       commit_message:
           prefix: "chore(deps)"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,13 @@
+version: 1
+update_configs:
+    - package_manager: "java:gradle"
+      directory: "./library/"
+      update_schedule: "daily"
+      commit_message:
+          prefix: "chore(deps)"
+
+    - package_manager: "java:gradle"
+      directory: "./demo/"
+      update_schedule: "daily"
+      commit_message:
+          prefix: "chore(deps)"


### PR DESCRIPTION
Adding dependabot config which checks the demo, maps-utils-ktx, and maps-ktx modules' dependencies on a daily basis. If a new version is found, a PR will be created by @dependabot.
