### PR TITLE
feat: Add suspending fun to MapView and StreetViewPanorama

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
             "minSdk"    : 15,
             "targetSdk" : 29
         ],
-        'androidMapsUtils' : '1.3.1',
+        'androidMapsUtils' : '2.0.1',
         'androidx'         : [
             'appcompat': '1.1.0',
             'coreKtx'  : '1.2.0',
@@ -31,7 +31,7 @@ buildscript {
             'junit'    : '1.1.1',
         ],
         'junit'            : '4.12',
-        'kotlin'           : '1.3.70',
+        'kotlin'           : '1.3.72',
         'kotlinxCoroutines': '1.3.2',
         'mapsBeta'         : '3.1.0-beta',
         'mockito'          : '3.0.0',

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/MapView.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/MapView.kt
@@ -1,0 +1,19 @@
+package com.google.maps.android.ktx
+
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.MapView
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * A suspending function that provides an instance of [GoogleMap] from this [MapView]. This is
+ * an alternative to [MapView.getMapAsync] by using coroutines to obtain the [GoogleMap].
+ *
+ * @return the [GoogleMap] instance
+ */
+suspend inline fun MapView.awaitMap(): GoogleMap =
+    suspendCoroutine { continuation ->
+        getMapAsync {
+            continuation.resume(it)
+        }
+    }

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/StreetViewPanoramaView.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/StreetViewPanoramaView.kt
@@ -1,0 +1,21 @@
+package com.google.maps.android.ktx
+
+import com.google.android.gms.maps.StreetViewPanorama
+import com.google.android.gms.maps.StreetViewPanoramaView
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * A suspending function that provides an instance of a [StreetViewPanorama] from this
+ * [StreetViewPanoramaView]. This is an alternative to using
+ * [StreetViewPanoramaView.getStreetViewPanoramaAsync] by using coroutines to obtain a
+ * [StreetViewPanorama].
+ *
+ * @return the [StreetViewPanorama] instance
+ */
+suspend inline fun StreetViewPanoramaView.awaitStreetViewPanorama(): StreetViewPanorama =
+    suspendCoroutine { continuation ->
+        getStreetViewPanoramaAsync {
+            continuation.resume(it)
+        }
+    }


### PR DESCRIPTION
Adds the following methods:

## MapView
```
val mapView: MapView = // ...
lifecycle.coroutineScope.launchWhenCreated {
    val googleMap = mapView.awaitMap()
}
```

## StreetViewPanoramaView

```
val view: StreetViewPanoramaView = // ...
lifecycle.coroutineScope.launchWhenCreated {
    val panoramaView = view.awaitStreetViewPanorama()
}
```

Additional changes:
* Bump Kotlin and Utility Library versions

Fixes #70
