### PR TITLE
feat: Modifying transitive dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It enables you to write more concise, idiomatic Kotlin. Each set of extensions c
 
 ## Requirements
 * Kotlin-enabled project
+* Kotlin coroutines
 * API level 15+
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository contains Kotlin extensions (KTX) for:
 It enables you to write more concise, idiomatic Kotlin. Each set of extensions can be used independently or together.
 
 ## Requirements
+* Kotlin-enabled project
 * API level 15+
 
 ## Installation

--- a/build.gradle
+++ b/build.gradle
@@ -58,10 +58,6 @@ buildscript {
         'mockito'          : "org.mockito:mockito-core:$versions.mockito",
         'mockitoKotlin'    : "com.nhaarman.mockitokotlin2:mockito-kotlin:$versions.mockitoKotlin",
         'playServices'     : [
-            'basement' : "com.google.android.gms:play-services-basement:$versions.playServices",
-            'base' : "com.google.android.gms:play-services-base:$versions.playServices",
-            'gcm' : "com.google.android.gms:play-services-gcm:$versions.playServices",
-            'location' : "com.google.android.gms:play-services-location:$versions.playServices",
             'maps' : "com.google.android.gms:play-services-maps:$versions.playServices",
         ],
     ]

--- a/maps-ktx/build.gradle
+++ b/maps-ktx/build.gradle
@@ -34,9 +34,9 @@ android {
 preBuild.dependsOn(rootProject.tasks.copyGmsToV3Beta)
 
 dependencies {
-    api deps.kotlin
+    implementation deps.kotlin
     implementation deps.kotlinxCoroutines
-    implementation deps.playServices.maps
+    api deps.playServices.maps
 
     // Tests
     testImplementation deps.androidx.test

--- a/maps-utils-ktx/build.gradle
+++ b/maps-utils-ktx/build.gradle
@@ -37,9 +37,9 @@ android {
 preBuild.dependsOn(rootProject.tasks.copyGmsUtilsToV3Beta)
 
 dependencies {
-    api deps.kotlin
+    implementation deps.kotlin
     api deps.androidMapsUtils.gms
-    implementation deps.playServices.maps
+    api deps.playServices.maps
 
     // Tests
     testImplementation deps.androidx.test

--- a/maps-utils-v3-ktx/build.gradle
+++ b/maps-utils-v3-ktx/build.gradle
@@ -35,14 +35,10 @@ android {
 }
 
 dependencies {
-    api deps.kotlin
-    api deps.androidMapsUtils.v3
+    implementation deps.kotlin
     implementation deps.kotlinxCoroutines
-    implementation deps.mapsBeta
-    implementation deps.playServices.base
-    implementation deps.playServices.basement
-    implementation deps.playServices.gcm
-    implementation deps.playServices.location
+    api deps.androidMapsUtils.v3
+    api deps.mapsBeta
 
     // Tests
     testImplementation deps.androidx.test

--- a/maps-v3-ktx/build.gradle
+++ b/maps-v3-ktx/build.gradle
@@ -32,13 +32,9 @@ android {
 }
 
 dependencies {
-    api deps.kotlin
+    implementation deps.kotlin
     implementation deps.kotlinxCoroutines
-    implementation deps.mapsBeta
-    implementation deps.playServices.base
-    implementation deps.playServices.basement
-    implementation deps.playServices.gcm
-    implementation deps.playServices.location
+    api deps.mapsBeta
 
     // Tests
     testImplementation deps.androidx.test


### PR DESCRIPTION
Modifying which dependencies are included in the compile scope vs. run-time scope. This is a breaking change.

**Run-time Dependencies**:
You must already have the Kotlin and Coroutine dependencies included in your Gradle file which IMO is an acceptable requirement (i.e. if you're even considering this KTX library, you must already have Kotlin configured in your project). Specifically, these must be defined in your app's `build.gradle` file.

```
dependencies {
    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.72"
    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.2"
}
```

**Compile-time Dependencies**
You will have these dependencies included at compile-time but these can still be overridden with a different version by explicitly adding the corresponding dependencies in your `build.gradle` file.

```
dependencies {
    // maps-ktx
    implementation "com.google.android.gms:play-services-maps:17.0.0"

    // maps-utils-ktx
    implementation "com.google.android.gms:play-services-maps:17.0.0"
    implementation "com.google.maps.android:android-maps-utils:2.0.1"

    // maps-v3-ktx
    implementation "com.google.android.libraries.maps:maps:3.1.0-beta"

    // maps-utils-v3-ktx
    implementation "com.google.android.libraries.maps:maps:3.1.0-beta"
    implementation "com.google.maps.android:android-maps-utils-v3:2.0.1"
}
```

BREAKING CHANGE: additional dependencies required for maps-ktx and
maps-utils-ktx