### PR TITLE
fix: Remove listeners in GoogleMap.cameraEvents(): Flow<CameraEvent> implementation

### DIFF
--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
@@ -64,13 +64,18 @@ data class CameraMoveStartedEvent(@MoveStartedReason val reason: Int) : CameraEv
  * [GoogleMap.setOnCameraMoveListener] and [GoogleMap.setOnCameraMoveStartedListener].
  */
 @ExperimentalCoroutinesApi
-inline fun GoogleMap.cameraEvents(): Flow<CameraEvent> =
+fun GoogleMap.cameraEvents(): Flow<CameraEvent> =
     callbackFlow {
         setOnCameraIdleListener { offer(CameraIdleEvent) }
         setOnCameraMoveCanceledListener { offer(CameraMoveCanceledEvent) }
         setOnCameraMoveListener { offer(CameraMoveEvent) }
         setOnCameraMoveStartedListener { offer(CameraMoveStartedEvent(it)) }
-        awaitClose()
+        awaitClose {
+            setOnCameraIdleListener(null)
+            setOnCameraMoveCanceledListener(null)
+            setOnCameraMoveListener(null)
+            setOnCameraMoveStartedListener(null)
+        }
     }
 
 /**


### PR DESCRIPTION
Fixes #80.

- Removed the added listeners in the `awaitClose` within the `GoogleMap.cameraEvents(): Flow<CameraEvent>` implementation.
- Removed the unnecessary `inline` keyword as the function has no parameters of function types.

Also made a couple of unrelated changes (let me know if you want them in a separate PR):
- Also bumped coroutines to version 1.3.8
- changed `kotlin-stdlib-jdk7` to `kotlin-stdlib` as no Java 7 APIs are used.

Ran `./gradlew assemble check` locally.


