### PR TITLE
chore: Update .releaserc README regexp.

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -11,8 +11,8 @@ plugins:
           to: "version = '${nextRelease.version}'"
         - files:
             - "README.md"
-          from: ":[0-9].[0-9].[0-9]"
-          to: ":${nextRelease.version}"
+          from: "ktx:[0-9].[0-9].[0-9]"
+          to: "ktx:${nextRelease.version}"
   - - "@semantic-release/git"
     - assets:
         - "./build.gradle"


### PR DESCRIPTION
Updating regexp so that only the ktx lib versions are bumped on a semantic release.
