### PR TITLE
feat: Add suspending awaitAnimation()

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,12 +11,24 @@
     See the License for the specific language governing permissions and
     limitations under the License.
  -->
-<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/map"
-    android:name="com.google.android.gms.maps.SupportMapFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.google.maps.android.ktx.demo.MainActivity">
 
-</fragment>
+    <fragment
+        android:id="@+id/map"
+        android:name="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <Button
+        android:id="@+id/button_animate_camera"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:padding="16dp"
+        android:text="Animate Camera" />
+
+</FrameLayout>


### PR DESCRIPTION
Adding `awaitAnimation()` which allows you to wait for an animation to complete within a coroutine scope. Particularly handy when you need to chain multiple animations together. Previously, you would need to nest a couple of `CancelableCallback`, this feature flattens it. Also updated sample app to demonstrate this.

https://user-images.githubusercontent.com/463186/108136603-3783d700-706f-11eb-884b-47d803438c53.mov\

**Before**
```kotlin
map.animateCamera(animation1, object : GoogleMap.CancelableCallback {
    override fun onFinish() {
        map.animateCamera(animation2,  object : GoogleMap.CancelableCallback {
            override fun onFinish() {
                map.animateCamera(animate3,  object : GoogleMap.CancelableCallback {
                    override fun onFinish() { // ...and so on }
                    override fun onCancel() { }
                })
            }
             override fun onCancel() { }
        })
    }

    override fun onCancel() { }
})
```

**After**
```kotlin
lifecycle.launchWhenStarted {
    map.run {
        awaitAnimation(animation1)
        awaitAnimation(animation2)
        awaitAnimation(animation3)
        // ...and so on
    }
}
```
