### PR TITLE
chore: Remove workflow_dispatch and update create-pull-request to v3.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,6 @@ on:
       - '*'
   repository_dispatch:
       types: [gh-pages]
-  workflow_dispatch:
 
 jobs:
   gh-page-sync:
@@ -49,12 +48,11 @@ jobs:
 
     # Commit changes and create a PR
     - name: PR Changes
-      uses: peter-evans/create-pull-request@v2
+      uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
         commit-message: 'docs: Update docs'
         committer: googlemaps-bot <googlemaps-bot@google.com>
-        author: googlemaps-bot <googlemaps-bot@google.com>
         title: 'docs: Update docs'
         body: |
             Updated GitHub pages with latest from `./gradlew dokka`.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,6 @@ on:
       - '*'
   repository_dispatch:
     types: [publish]
-  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
Removing `workflow_dispatch` in an attempt to fix #120. Workflows can still be triggered using `repository_dispatch`.
