### PR TITLE
fix: Rename awaitAnimation to awaitAnimateCamera

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Run tests
       run: |
         echo "Running unit tests"
-        ./gradlew check test -x lint --stacktrace
+        ./gradlew check test jacocoTestReport -x lint --stacktrace
 
         echo "Sending test results to CodeCov"
         bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Run tests
       run: |
         echo "Running unit tests"
-        ./gradlew check test jacocoTestReport -x lint --stacktrace
+        ./gradlew check test -x lint --stacktrace
 
         echo "Sending test results to CodeCov"
         bash <(curl -s https://codecov.io/bash)

--- a/app/src/main/java/com/google/maps/android/ktx/demo/MainActivity.kt
+++ b/app/src/main/java/com/google/maps/android/ktx/demo/MainActivity.kt
@@ -24,12 +24,10 @@ import android.widget.ImageView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.coroutineScope
-import com.google.android.gms.maps.CameraUpdate
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.BitmapDescriptorFactory
-import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.clustering.ClusterManager
 import com.google.maps.android.collections.GroundOverlayManager
@@ -43,7 +41,7 @@ import com.google.maps.android.ktx.CameraIdleEvent
 import com.google.maps.android.ktx.CameraMoveCanceledEvent
 import com.google.maps.android.ktx.CameraMoveEvent
 import com.google.maps.android.ktx.CameraMoveStartedEvent
-import com.google.maps.android.ktx.awaitAnimation
+import com.google.maps.android.ktx.awaitAnimateCamera
 import com.google.maps.android.ktx.awaitMap
 import com.google.maps.android.ktx.awaitMapLoad
 import com.google.maps.android.ktx.awaitSnapshot
@@ -115,7 +113,7 @@ class MainActivity : AppCompatActivity() {
             currentLocation = if (currentLocation == london) sanFrancisco else london
             lifecycle.coroutineScope.launchWhenStarted {
                 googleMap.run {
-                    awaitAnimation(CameraUpdateFactory.newCameraPosition(
+                    awaitAnimateCamera(CameraUpdateFactory.newCameraPosition(
                         cameraPosition {
                             target(currentLocation)
                             zoom(0.0f)
@@ -124,7 +122,7 @@ class MainActivity : AppCompatActivity() {
                         }
                     ))
                     awaitMapLoad()
-                    awaitAnimation(CameraUpdateFactory.newCameraPosition(
+                    awaitAnimateCamera(CameraUpdateFactory.newCameraPosition(
                         cameraPosition {
                             target(currentLocation)
                             zoom(10.0f)

--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,7 @@ subprojects { project ->
 
     tasks.withType(Test) {
         jacoco.includeNoLocationClasses = true
+        jacoco.excludes = ['jdk.internal.*']
     }
 
     task sourcesJar(type: Jar) {

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
@@ -105,7 +105,7 @@ public fun GoogleMap.cameraEvents(): Flow<CameraEvent> =
  * @param cameraUpdate the [CameraUpdate] to apply on the map
  * @param durationMs the duration in milliseconds of the animation. Defaults to 3 seconds.
  */
-public suspend inline fun GoogleMap.awaitAnimation(
+public suspend inline fun GoogleMap.awaitAnimateCamera(
     cameraUpdate: CameraUpdate,
     durationMs: Int = 3000
 ): Unit =


### PR DESCRIPTION
Renamed `awaitAnimation` to `awaitAnimateCamera` to match the underlying method name. Not only does this match the original method, but this is also a lot more specific. The former method name could be confusing since it's not clear what is being animated.

BREAKING CHANGE: Renamed `awaitAnimation` to `awaitAnimateCamera`