### PR TITLE
fix: Assign unique package names to libs.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,11 +49,11 @@ dependencies {
     implementation deps.kotlin
     implementation deps.androidx.appcompat
     implementation deps.androidx.coreKtx
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0'
-    implementation 'com.google.android.gms:play-services-maps:17.0.0'
-//    implementation 'com.google.maps.android:maps-ktx:2.0.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
+    implementation 'com.google.android.gms:play-services-maps:17.0.1'
+    implementation 'com.google.maps.android:maps-ktx:3.0.0'
     implementation 'com.google.maps.android:maps-utils-ktx:3.0.0'
-    implementation project(':maps-ktx')
+//    implementation project(':maps-ktx')
 //    implementation project(':maps-utils-ktx')
 }
 

--- a/maps-ktx/src/main/AndroidManifest.xml
+++ b/maps-ktx/src/main/AndroidManifest.xml
@@ -15,4 +15,4 @@
   ~
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.maps.android.ktx" />
+    package="com.google.maps.android.v3.ktx" />

--- a/maps-utils-ktx/src/main/AndroidManifest.xml
+++ b/maps-utils-ktx/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.maps.android" />
+    package="com.google.maps.android.ktx.utils" />

--- a/maps-utils-v3-ktx/src/main/AndroidManifest.xml
+++ b/maps-utils-v3-ktx/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.maps.android" />
+    package="com.google.maps.android.ktx.utils" />

--- a/maps-v3-ktx/src/main/AndroidManifest.xml
+++ b/maps-v3-ktx/src/main/AndroidManifest.xml
@@ -15,4 +15,4 @@
   ~
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.maps.android.ktx" />
+    package="com.google.maps.android.v3.ktx" />


### PR DESCRIPTION
Builds were presenting a warning when the `maps-utils-ktx` library is used since the manifest package name conflicts with the utility library's package name. This change assigns unique package names to each lib in this repo.

Fixes #135 🦕
