### PR TITLE
chore: Update secrets-gradle-plugin to 1.1.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-    id 'com.google.secrets_gradle_plugin' version '0.6'
+    id 'com.google.android.secrets-gradle-plugin' version '1.1.0'
 }
 
 android {


### PR DESCRIPTION
Update `secrets-gradle-plugin` to v1.1.0
