### PR TITLE
chore: Set sourceCompatibility and targetCompatibility to 1.8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,11 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     kotlinOptions {
         freeCompilerArgs += ["-Xopt-in=kotlin.RequiresOptIn"]
         jvmTarget = "1.8"

--- a/maps-ktx/build.gradle
+++ b/maps-ktx/build.gradle
@@ -30,6 +30,11 @@ android {
         consumerProguardFiles 'consumer-rules.pro'
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     kotlinOptions {
         freeCompilerArgs += '-Xexplicit-api=strict'
         jvmTarget = "1.8"

--- a/maps-utils-ktx/build.gradle
+++ b/maps-utils-ktx/build.gradle
@@ -33,6 +33,11 @@ android {
         it.generateBuildConfig.enabled = false
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     kotlinOptions {
         freeCompilerArgs += '-Xexplicit-api=strict'
         jvmTarget = "1.8"

--- a/maps-utils-v3-ktx/build.gradle
+++ b/maps-utils-v3-ktx/build.gradle
@@ -33,6 +33,11 @@ android {
         it.generateBuildConfig.enabled = false
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     kotlinOptions {
         freeCompilerArgs += '-Xexplicit-api=strict'
         jvmTarget = "1.8"

--- a/maps-v3-ktx/build.gradle
+++ b/maps-v3-ktx/build.gradle
@@ -30,6 +30,11 @@ android {
         consumerProguardFiles 'consumer-rules.pro'
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     kotlinOptions {
         freeCompilerArgs += '-Xexplicit-api=strict'
         jvmTarget = "1.8"


### PR DESCRIPTION
Fix based on recommended fixes from `release` workflow failure: https://github.com/googlemaps/android-maps-ktx/runs/3625368037?check_suite_focus=true
