### PR TITLE
fix: Add missing reason for cameraMoveStartedEvents() flow

### DIFF
--- a/app/src/main/java/com/google/maps/android/ktx/demo/MainActivity.kt
+++ b/app/src/main/java/com/google/maps/android/ktx/demo/MainActivity.kt
@@ -37,18 +37,7 @@ import com.google.maps.android.collections.PolylineManager
 import com.google.maps.android.data.Renderer.ImagesCache
 import com.google.maps.android.data.geojson.GeoJsonLineStringStyle
 import com.google.maps.android.data.geojson.GeoJsonPolygonStyle
-import com.google.maps.android.ktx.CameraIdleEvent
-import com.google.maps.android.ktx.CameraMoveCanceledEvent
-import com.google.maps.android.ktx.CameraMoveEvent
-import com.google.maps.android.ktx.CameraMoveStartedEvent
-import com.google.maps.android.ktx.awaitAnimateCamera
-import com.google.maps.android.ktx.awaitMap
-import com.google.maps.android.ktx.awaitMapLoad
-import com.google.maps.android.ktx.awaitSnapshot
-import com.google.maps.android.ktx.cameraEvents
-import com.google.maps.android.ktx.awaitMap
-import com.google.maps.android.ktx.cameraIdleEvents
-import com.google.maps.android.ktx.cameraMoveStartedEvents
+import com.google.maps.android.ktx.*
 import com.google.maps.android.ktx.demo.io.MyItemReader
 import com.google.maps.android.ktx.demo.model.MyItem
 import com.google.maps.android.ktx.model.cameraPosition
@@ -100,7 +89,7 @@ class MainActivity : AppCompatActivity() {
             addButtonClickListener(googleMap)
             launch {
                 googleMap.cameraMoveStartedEvents().collect {
-                    Log.d(TAG, "Camera moved.")
+                    Log.d(TAG, "Camera moved - reason $it")
                 }
             }
             launch {

--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/GoogleMap.kt
@@ -23,29 +23,9 @@ import androidx.annotation.IntDef
 import com.google.android.gms.maps.CameraUpdate
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.GoogleMapOptions
-import com.google.android.gms.maps.model.Circle
-import com.google.android.gms.maps.model.CircleOptions
-import com.google.android.gms.maps.model.GroundOverlay
-import com.google.android.gms.maps.model.GroundOverlayOptions
-import com.google.android.gms.maps.model.IndoorBuilding
-import com.google.android.gms.maps.model.LatLng
-import com.google.android.gms.maps.model.Marker
-import com.google.android.gms.maps.model.MarkerOptions
-import com.google.android.gms.maps.model.PointOfInterest
-import com.google.android.gms.maps.model.Polygon
-import com.google.android.gms.maps.model.PolygonOptions
-import com.google.android.gms.maps.model.Polyline
-import com.google.android.gms.maps.model.PolylineOptions
-import com.google.android.gms.maps.model.TileOverlay
-import com.google.android.gms.maps.model.TileOverlayOptions
-import com.google.maps.android.ktx.model.circleOptions
-import com.google.maps.android.ktx.model.groundOverlayOptions
-import com.google.maps.android.ktx.model.markerOptions
-import com.google.maps.android.ktx.model.polygonOptions
-import com.google.maps.android.ktx.model.polylineOptions
-import com.google.maps.android.ktx.model.tileOverlayOptions
+import com.google.android.gms.maps.model.*
+import com.google.maps.android.ktx.model.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -234,10 +214,10 @@ public suspend inline fun GoogleMap.awaitSnapshot(bitmap: Bitmap? = null): Bitma
  * events will override an existing listener (if any) to [GoogleMap.setOnCameraMoveStartedListener].
  */
 @ExperimentalCoroutinesApi
-public fun GoogleMap.cameraMoveStartedEvents(): Flow<Unit> =
+public fun GoogleMap.cameraMoveStartedEvents(): Flow<Int> =
     callbackFlow {
         setOnCameraMoveStartedListener {
-            trySend(Unit)
+            trySend(it)
         }
         awaitClose {
             setOnCameraMoveStartedListener(null)


### PR DESCRIPTION
Currently the `reason` parameter from `onCameraMoveStarted (int reason)` method in the `GoogleMap.OnCameraMoveStartedListener` isn't being passed through to the Flow:
https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap.OnCameraMoveStartedListener

This PR passes the integer value through to the Flow.

Also add it to the demo app.

Closes #168

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #168 🦕
