### PR TITLE
chore: setting Java 17 for the release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
     - name: Checkout
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
This PR sets the Java version 17 for the release flow.