### PR TITLE
chore: using auto-merge label

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,7 +58,9 @@ jobs:
         commit-message: 'docs: Update docs'
         author: googlemaps-bot <googlemaps-bot@google.com>
         committer: googlemaps-bot <googlemaps-bot@google.com>
-        labels: docs
+        labels: |
+          docs
+          automerge
         title: 'docs: Update docs'
         body: |
             Updated GitHub pages with latest from `./gradlew dokka`.


### PR DESCRIPTION
This PR will set the PRs coming from the docs.yml workflow as automatically approved for merge, so we don't need to release them manually with each release.