### PR TITLE
chore: remove automerge

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -31,5 +31,3 @@ jobs:
     steps:
       - name: approve
         run: gh pr review --approve "$PR_URL"
-      - name: merge
-        run: gh pr merge --auto --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
This PR removes the automerge from android-maps-ktx, which we want to avoid to prevent errors during runtime.