### PR TITLE
fix: fixed release config

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,8 +7,8 @@ plugins:
     - replacements:
         - files:
             - "build.gradle.kts"
-          from: "\\bversion = '.*'"
-          to: "version = '${nextRelease.version}'"
+          from: "\\bversion = \".*\""
+          to: "version = \"${nextRelease.version}\""
         - files:
             - "README.md"
           from: ":([0-9]+).([0-9]+).([0-9]+)"


### PR DESCRIPTION
This PR fixes a configuration line on the .releaserc flow to change the version after a release has been done (i.e., KTS files must use now " instead of ')