### PR TITLE
chore: migrating to vanniktech plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,9 @@ jobs:
         gpg --quiet --output $GITHUB_WORKSPACE/release.gpg --dearmor ./release.asc
 
         echo "Build and publish"
-        sed -i -e "s,sonatypeToken=,sonatypeToken=$SONATYPE_TOKEN_USERNAME,g" gradle.properties
+        sed -i -e "s,mavenCentralUsername=,mavenCentralUsername=$SONATYPE_TOKEN_USERNAME,g" gradle.properties
         SONATYPE_TOKEN_PASSWORD_ESCAPED=$(printf '%s\n' "$SONATYPE_TOKEN_PASSWORD" | sed -e 's/[\/&]/\\&/g')
-        sed -i -e "s,sonatypeTokenPassword=,sonatypeTokenPassword=$SONATYPE_TOKEN_PASSWORD_ESCAPED,g" gradle.properties
+        sed -i -e "s,mavenCentralPassword=,mavenCentralPassword=$SONATYPE_TOKEN_PASSWORD_ESCAPED,g" gradle.properties
         sed -i -e "s,signing.keyId=,signing.keyId=$GPG_KEY_ID,g" gradle.properties
         sed -i -e "s,signing.password=,signing.password=$GPG_PASSWORD,g" gradle.properties
         sed -i -e "s,signing.secretKeyRingFile=,signing.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg,g" gradle.properties

--- a/.releaserc
+++ b/.releaserc
@@ -15,7 +15,7 @@ plugins:
           to: ":${nextRelease.version}"
   - - "@semantic-release/exec"
     - prepareCmd: "./gradlew build --warn --stacktrace"
-      publishCmd: "./gradlew publish --warn --stacktrace"
+      publishCmd: "./gradlew publishToMavenCentral --warn --stacktrace"
   - - "@semantic-release/git"
     - assets:
         - "build.gradle.kts"

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(libs.gradle)
     implementation(libs.dokkaGradlePlugin)
     implementation(libs.org.jacoco.core)
+    implementation(libs.gradle.maven.publish.plugin)
 }
 
 gradlePlugin {

--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -1,38 +1,32 @@
 // buildSrc/src/main/kotlin/PublishingConventionPlugin.kt
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.*
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import org.gradle.api.tasks.testing.Test
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
-import org.gradle.plugins.signing.SigningExtension
-import org.gradle.api.publish.maven.*
 
 class PublishingConventionPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         project.run {
-
             applyPlugins()
             configureJacoco()
-            configurePublishing()
-            configureSigning()
+            configureVanniktechPublishing()
         }
     }
 
     private fun Project.applyPlugins() {
         apply(plugin = "com.android.library")
         apply(plugin = "com.mxalbert.gradle.jacoco-android")
-        apply(plugin = "maven-publish")
         apply(plugin = "org.jetbrains.dokka")
-        apply(plugin = "signing")
+        apply(plugin = "com.vanniktech.maven.publish")
     }
 
     private fun Project.configureJacoco() {
         configure<JacocoPluginExtension> {
             toolVersion = "0.8.7"
-
         }
 
         tasks.withType<Test>().configureEach {
@@ -43,68 +37,46 @@ class PublishingConventionPlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.configurePublishing() {
-        extensions.configure<com.android.build.gradle.LibraryExtension> {
-            publishing {
-                singleVariant("release") {
-                    withSourcesJar()
-                    withJavadocJar()
-                }
-            }
-        }
-        extensions.configure<PublishingExtension> {
-            publications {
-                create<MavenPublication>("aar") {
-                    afterEvaluate {
-                        from(components["release"])
-                    }
-                    pom {
-                        name.set(project.name)
-                        description.set("Kotlin extensions (KTX) for Google Maps SDK")
-                        url.set("https://github.com/googlemaps/android-maps-ktx")
-                        scm {
-                            connection.set("scm:git@github.com:googlemaps/android-maps-ktx.git")
-                            developerConnection.set("scm:git@github.com:googlemaps/android-maps-ktx.git")
-                            url.set("https://github.com/googlemaps/android-maps-ktx")
-                        }
-                        licenses {
-                            license {
-                                name.set("The Apache Software License, Version 2.0")
-                                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                                distribution.set("repo")
-                            }
-                        }
-                        organization {
-                            name.set("Google Inc")
-                            url.set("http://developers.google.com/maps")
-                        }
-                        developers {
-                            developer {
-                                name.set("Google Inc.")
-                            }
-                        }
-                    }
-                }
-            }
-            repositories {
-                maven {
-                    val releasesRepoUrl =
-                        uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
-                    val snapshotsRepoUrl =
-                        uri("https://central.sonatype.com/repository/maven-snapshots/")
-                    url = if (project.version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
-                    credentials {
-                        username = project.findProperty("sonatypeToken") as String?
-                        password = project.findProperty("sonatypeTokenPassword") as String?
-                    }
-                }
-            }
-        }
-    }
+    private fun Project.configureVanniktechPublishing() {
+        extensions.configure<MavenPublishBaseExtension> {
+            configure(
+                AndroidSingleVariantLibrary(
+                    variant = "release",
+                    sourcesJar = true,
+                    publishJavadocJar = true
+                )
+            )
 
-    private fun Project.configureSigning() {
-        configure<SigningExtension> {
-            sign(extensions.getByType<PublishingExtension>().publications["aar"])
+            publishToMavenCentral()
+            signAllPublications()
+
+            pom {
+                name.set(project.name)
+                description.set("Kotlin extensions (KTX) for Google Maps SDK")
+                url.set("https://github.com/googlemaps/android-maps-ktx")
+                licenses {
+                    license {
+                        name.set("The Apache Software License, Version 2.0")
+                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        distribution.set("repo")
+                    }
+                }
+                scm {
+                    connection.set("scm:git@github.com:googlemaps/android-maps-ktx.git")
+                    developerConnection.set("scm:git@github.com:googlemaps/android-maps-ktx.git")
+                    url.set("https://github.com/googlemaps/android-maps-ktx")
+                }
+                organization {
+                    name.set("Google Inc")
+                    url.set("http://developers.google.com/maps")
+                }
+                developers {
+                    developer {
+                        id.set("google")
+                        name.set("Google Inc.")
+                    }
+                }
+            }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,9 +29,16 @@ android.defaults.buildfeatures.buildconfig=true
 sonatypeToken=
 sonatypeTokenPassword=
 
+mavenCentralUsername=
+mavenCentralPassword=
+
 # Migration to AGP 8.2.1
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 
 # Despite being deprecated, targeting lowest java version is needed to support old Android runtime
 android.javaCompile.suppressSourceTargetDeprecationWarning=true
+
+# Add a property to enable automatic release to Maven Central (optional, but good for CI)
+# If true, publishToMavenCentral will also close and release the staging repository
+mavenCentralAutomaticRelease=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,8 +26,6 @@ signing.keyId=
 signing.password=
 signing.secretKeyRingFile=
 android.defaults.buildfeatures.buildconfig=true
-sonatypeToken=
-sonatypeTokenPassword=
 
 mavenCentralUsername=
 mavenCentralPassword=

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ mockitoInline = "5.2.0"
 mockitoKotlin = "2.2.0"
 secretsGradlePlugin = "2.0.1"
 org-jacoco-core = "0.8.13"
+gradleMavenPublishPlugin = "0.34.0"
 
 [libraries]
 androidMapsUtils = { group = "com.google.maps.android", name = "android-maps-utils", version.ref = "androidMapsUtils" }
@@ -42,3 +43,4 @@ mockitoKotlin = { group = "com.nhaarman.mockitokotlin2", name = "mockito-kotlin"
 playServicesMaps = { group = "com.google.android.gms", name = "play-services-maps", version.ref = "androidMapsSdk" }
 secretsGradlePlugin = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "secretsGradlePlugin" }
 org-jacoco-core = { module = "org.jacoco:org.jacoco.core", version.ref = "org-jacoco-core" }
+gradle-maven-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "gradleMavenPublishPlugin" }


### PR DESCRIPTION
The following PR migrates from the maven-publish plugin to vanniktech, to support the new Maven Central.

This PR provides the new configuration and data we need (including the maven central username and password)