### PR TITLE
build: fix dokka url

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,8 +43,8 @@ jobs:
         ./gradlew dokkaHtml
 
         echo "Creating tar for generated docs"
-        cd $GITHUB_WORKSPACE/maps-utils-ktx/build/documentation && tar cvf ~/maps-utils-docs.tar .
-        cd $GITHUB_WORKSPACE/maps-ktx/build/documentation && tar cvf ~/maps-docs.tar .
+        cd $GITHUB_WORKSPACE/maps-utils-ktx/build/dokka && tar cvf ~/maps-utils-docs.tar .
+        cd $GITHUB_WORKSPACE/maps-ktx/build/dokka && tar cvf ~/maps-docs.tar .
 
         echo "Unpacking tar into gh-pages branch"
         git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*


### PR DESCRIPTION
This issue fixes the path for the new Dokka plugin.