### PR TITLE
chore: run lint only on PR

### DIFF
--- a/.github/workflows/lint-report.yml
+++ b/.github/workflows/lint-report.yml
@@ -15,9 +15,6 @@
 name: Lint and Upload SARIF
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This PR runs the Lint workflow only on PRs.