### PR TITLE
feat(flow): add Kotlin Flow extensions to maps-utils-ktx managers

### DIFF
--- a/app/src/main/java/com/google/maps/android/ktx/demo/MainActivity.kt
+++ b/app/src/main/java/com/google/maps/android/ktx/demo/MainActivity.kt
@@ -55,7 +55,10 @@ import com.google.maps.android.ktx.demo.io.MyItemReader
 import com.google.maps.android.ktx.demo.model.CacheViewModel
 import com.google.maps.android.ktx.demo.model.MyItem
 import com.google.maps.android.ktx.model.cameraPosition
+import com.google.maps.android.ktx.utils.clustering.clusterClickEvents
+import com.google.maps.android.ktx.utils.clustering.clusterItemClickEvents
 import com.google.maps.android.ktx.utils.collection.addMarker
+import com.google.maps.android.ktx.utils.collection.clickEvents
 import com.google.maps.android.ktx.utils.geojson.geoJsonLayer
 import com.google.maps.android.ktx.utils.kml.kmlLayer
 import kotlinx.coroutines.launch
@@ -177,6 +180,23 @@ class MainActivity : AppCompatActivity() {
     private fun addClusters(map: GoogleMap, markerManager: MarkerManager) {
         val clusterManager = ClusterManager<MyItem>(this, map, markerManager)
         map.setOnCameraIdleListener(clusterManager)
+
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch {
+                    clusterManager.clusterClickEvents().collect { cluster ->
+                        Log.d(TAG, "Cluster clicked! Size: ${cluster.size}")
+                        Toast.makeText(this@MainActivity, "Cluster clicked! Size: ${cluster.size}", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                launch {
+                    clusterManager.clusterItemClickEvents().collect { item ->
+                        Log.d(TAG, "Cluster item clicked: ${item.title}")
+                        Toast.makeText(this@MainActivity, "Cluster item clicked: ${item.title}", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+        }
 
         try {
             val items = MyItemReader().read(resources.openRawResource(R.raw.radar_search))
@@ -303,13 +323,17 @@ class MainActivity : AppCompatActivity() {
             icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE))
             title("Unclustered marker")
         }
-        markerCollection.setOnMarkerClickListener { marker ->
-            Toast.makeText(
-                this,
-                "Marker clicked: " + marker.title,
-                Toast.LENGTH_SHORT
-            ).show()
-            false
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                markerCollection.clickEvents().collect { marker ->
+                    Log.d(TAG, "Marker clicked via Flow: ${marker.title}")
+                    Toast.makeText(
+                        this@MainActivity,
+                        "Marker clicked via Flow: " + marker.title,
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
         }
     }
 

--- a/maps-utils-ktx/build.gradle.kts
+++ b/maps-utils-ktx/build.gradle.kts
@@ -66,4 +66,5 @@ dependencies {
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.mockito.inline)
     testImplementation(libs.truth)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/clustering/ClusterManager.kt
+++ b/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/clustering/ClusterManager.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.utils.clustering
+
+import com.google.maps.android.clustering.Cluster
+import com.google.maps.android.clustering.ClusterItem
+import com.google.maps.android.clustering.ClusterManager
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+/**
+ * Returns a flow that emits when a cluster is clicked. Using this to observe cluster clicks
+ * will override an existing listener (if any) to [ClusterManager.setOnClusterClickListener].
+ */
+public fun <T : ClusterItem> ClusterManager<T>.clusterClickEvents(): Flow<Cluster<T>> =
+    callbackFlow {
+        setOnClusterClickListener {
+            trySend(it).isSuccess
+        }
+        awaitClose {
+            setOnClusterClickListener(null)
+        }
+    }
+
+/**
+ * Returns a flow that emits when a cluster item is clicked. Using this to observe cluster item clicks
+ * will override an existing listener (if any) to [ClusterManager.setOnClusterItemClickListener].
+ */
+public fun <T : ClusterItem> ClusterManager<T>.clusterItemClickEvents(): Flow<T> =
+    callbackFlow {
+        setOnClusterItemClickListener {
+            trySend(it).isSuccess
+        }
+        awaitClose {
+            setOnClusterItemClickListener(null)
+        }
+    }
+
+/**
+ * Returns a flow that emits when a cluster's info window is clicked. Using this to observe cluster info window clicks
+ * will override an existing listener (if any) to [ClusterManager.setOnClusterInfoWindowClickListener].
+ */
+public fun <T : ClusterItem> ClusterManager<T>.clusterInfoWindowClickEvents(): Flow<Cluster<T>> =
+    callbackFlow {
+        setOnClusterInfoWindowClickListener {
+            trySend(it).isSuccess
+        }
+        awaitClose {
+            setOnClusterInfoWindowClickListener(null)
+        }
+    }
+
+/**
+ * Returns a flow that emits when a cluster's info window is long clicked. Using this to observe cluster info window long clicks
+ * will override an existing listener (if any) to [ClusterManager.setOnClusterInfoWindowLongClickListener].
+ */
+public fun <T : ClusterItem> ClusterManager<T>.clusterInfoWindowLongClickEvents(): Flow<Cluster<T>> =
+    callbackFlow {
+        setOnClusterInfoWindowLongClickListener {
+            trySend(it).isSuccess
+        }
+        awaitClose {
+            setOnClusterInfoWindowLongClickListener(null)
+        }
+    }
+
+/**
+ * Returns a flow that emits when a cluster item's info window is clicked. Using this to observe cluster item info window clicks
+ * will override an existing listener (if any) to [ClusterManager.setOnClusterItemInfoWindowClickListener].
+ */
+public fun <T : ClusterItem> ClusterManager<T>.clusterItemInfoWindowClickEvents(): Flow<T> =
+    callbackFlow {
+        setOnClusterItemInfoWindowClickListener {
+            trySend(it).isSuccess
+        }
+        awaitClose {
+            setOnClusterItemInfoWindowClickListener(null)
+        }
+    }
+
+/**
+ * Returns a flow that emits when a cluster item's info window is long clicked. Using this to observe cluster item info window long clicks
+ * will override an existing listener (if any) to [ClusterManager.setOnClusterItemInfoWindowLongClickListener].
+ */
+public fun <T : ClusterItem> ClusterManager<T>.clusterItemInfoWindowLongClickEvents(): Flow<T> =
+    callbackFlow {
+        setOnClusterItemInfoWindowLongClickListener {
+            trySend(it).isSuccess
+        }
+        awaitClose {
+            setOnClusterItemInfoWindowLongClickListener(null)
+        }
+    }

--- a/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/CircleManager.kt
+++ b/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/CircleManager.kt
@@ -20,6 +20,9 @@ package com.google.maps.android.ktx.utils.collection
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.CircleOptions
 import com.google.maps.android.collections.CircleManager
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 
 /**
  * Adds a new [Circle] to the underlying map and to this [CircleManager.Collection] with the
@@ -29,3 +32,17 @@ public inline fun CircleManager.Collection.addCircle(optionsActions: CircleOptio
     this.addCircle(
         CircleOptions().apply(optionsActions)
     )
+
+/**
+ * Returns a flow that emits when a circle in this collection is clicked. Using this to observe circle clicks
+ * will override an existing listener (if any) to [CircleManager.Collection.setOnCircleClickListener].
+ */
+public fun CircleManager.Collection.clickEvents(): Flow<Circle> =
+    callbackFlow {
+        setOnCircleClickListener {
+            trySend(it).isSuccess
+        }
+        awaitClose {
+            setOnCircleClickListener(null)
+        }
+    }

--- a/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/GroundOverlayManager.kt
+++ b/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/GroundOverlayManager.kt
@@ -20,6 +20,9 @@ package com.google.maps.android.ktx.utils.collection
 import com.google.android.gms.maps.model.GroundOverlay
 import com.google.android.gms.maps.model.GroundOverlayOptions
 import com.google.maps.android.collections.GroundOverlayManager
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 
 /**
  * Adds a new [GroundOverlay] to the underlying map and to this [GroundOverlayManager.Collection]
@@ -31,3 +34,17 @@ public inline fun GroundOverlayManager.Collection.addGroundOverlay(
     this.addGroundOverlay(
         GroundOverlayOptions().apply(optionsActions)
     )
+
+/**
+ * Returns a flow that emits when a ground overlay in this collection is clicked. Using this to observe ground overlay clicks
+ * will override an existing listener (if any) to [GroundOverlayManager.Collection.setOnGroundOverlayClickListener].
+ */
+public fun GroundOverlayManager.Collection.clickEvents(): Flow<GroundOverlay> =
+    callbackFlow {
+        setOnGroundOverlayClickListener {
+            trySend(it).isSuccess
+        }
+        awaitClose {
+            setOnGroundOverlayClickListener(null)
+        }
+    }

--- a/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/MarkerManager.kt
+++ b/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/MarkerManager.kt
@@ -20,6 +20,9 @@ package com.google.maps.android.ktx.utils.collection
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 import com.google.maps.android.collections.MarkerManager
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 
 /**
  * Adds a new [Marker] to the underlying map and to this [MarkerManager.Collection] with the
@@ -29,3 +32,47 @@ public inline fun MarkerManager.Collection.addMarker(optionsActions: MarkerOptio
     this.addMarker(
         MarkerOptions().apply(optionsActions)
     )
+
+/**
+ * Returns a flow that emits when a marker in this collection is clicked. Using this to observe marker clicks
+ * will override an existing listener (if any) to [MarkerManager.Collection.setOnMarkerClickListener].
+ */
+public fun MarkerManager.Collection.clickEvents(): Flow<Marker> =
+    callbackFlow {
+        setOnMarkerClickListener {
+            trySend(it).isSuccess
+        }
+        awaitClose {
+            setOnMarkerClickListener(null)
+        }
+    }
+
+/**
+ * Returns a flow that emits when a marker's info window in this collection is clicked. Using this to observe info window clicks
+ * will override an existing listener (if any) to [MarkerManager.Collection.setOnInfoWindowClickListener].
+ */
+public fun MarkerManager.Collection.infoWindowClickEvents(): Flow<Marker> =
+    callbackFlow {
+        setOnInfoWindowClickListener {
+            trySend(it).isSuccess
+        }
+        awaitClose {
+            setOnInfoWindowClickListener(null)
+        }
+    }
+
+
+
+/**
+ * Returns a flow that emits when a marker's info window in this collection is long clicked. Using this to observe info window long clicks
+ * will override an existing listener (if any) to [MarkerManager.Collection.setOnInfoWindowLongClickListener].
+ */
+public fun MarkerManager.Collection.infoWindowLongClickEvents(): Flow<Marker> =
+    callbackFlow {
+        setOnInfoWindowLongClickListener {
+            trySend(it).isSuccess
+        }
+        awaitClose {
+            setOnInfoWindowLongClickListener(null)
+        }
+    }

--- a/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/PolygonManager.kt
+++ b/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/PolygonManager.kt
@@ -18,10 +18,22 @@
 package com.google.maps.android.ktx.utils.collection
 
 import com.google.android.gms.maps.model.Polygon
+import com.google.android.gms.maps.model.PolygonOptions
 import com.google.maps.android.collections.PolygonManager
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+
+/**
+ * Adds a new [Polygon] to the underlying map and to this [PolygonManager.Collection] with the
+ * provided [optionsActions].
+ */
+public inline fun PolygonManager.Collection.addPolygon(
+    optionsActions: PolygonOptions.() -> Unit
+): Polygon =
+    this.addPolygon(
+        PolygonOptions().apply(optionsActions)
+    )
 
 /**
  * Returns a flow that emits when a polygon in this collection is clicked. Using this to observe polygon clicks

--- a/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/PolygonManager.kt
+++ b/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/PolygonManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google Inc.
+ * Copyright 2026 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,21 @@
 package com.google.maps.android.ktx.utils.collection
 
 import com.google.android.gms.maps.model.Polygon
-import com.google.android.gms.maps.model.PolygonOptions
 import com.google.maps.android.collections.PolygonManager
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 
 /**
- * Adds a new [Polygon] to the underlying map and to this [PolygonManager.Collection] with the
- * provided [optionsActions].
+ * Returns a flow that emits when a polygon in this collection is clicked. Using this to observe polygon clicks
+ * will override an existing listener (if any) to [PolygonManager.Collection.setOnPolygonClickListener].
  */
-public inline fun PolygonManager.Collection.addPolygon(
-    optionsActions: PolygonOptions.() -> Unit
-): Polygon =
-    this.addPolygon(
-        PolygonOptions().apply(optionsActions)
-    )
+public fun PolygonManager.Collection.clickEvents(): Flow<Polygon> =
+    callbackFlow {
+        setOnPolygonClickListener {
+            trySend(it).isSuccess
+        }
+        awaitClose {
+            setOnPolygonClickListener(null)
+        }
+    }

--- a/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/PolylineManager.kt
+++ b/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/PolylineManager.kt
@@ -18,10 +18,22 @@
 package com.google.maps.android.ktx.utils.collection
 
 import com.google.android.gms.maps.model.Polyline
+import com.google.android.gms.maps.model.PolylineOptions
 import com.google.maps.android.collections.PolylineManager
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+
+/**
+ * Adds a new [Polyline] to the underlying map and to this [PolylineManager.Collection] with the
+ * provided [optionsActions].
+ */
+public inline fun PolylineManager.Collection.addPolyline(
+    optionsActions: PolylineOptions.() -> Unit
+): Polyline =
+    this.addPolyline(
+        PolylineOptions().apply(optionsActions)
+    )
 
 /**
  * Returns a flow that emits when a polyline in this collection is clicked. Using this to observe polyline clicks

--- a/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/PolylineManager.kt
+++ b/maps-utils-ktx/src/main/java/com/google/maps/android/ktx/utils/collection/PolylineManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google Inc.
+ * Copyright 2026 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,21 @@
 package com.google.maps.android.ktx.utils.collection
 
 import com.google.android.gms.maps.model.Polyline
-import com.google.android.gms.maps.model.PolylineOptions
 import com.google.maps.android.collections.PolylineManager
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 
 /**
- * Adds a new [Polyline] to the underlying map and to this [PolylineManager.Collection] with the
- * provided [optionsActions].
+ * Returns a flow that emits when a polyline in this collection is clicked. Using this to observe polyline clicks
+ * will override an existing listener (if any) to [PolylineManager.Collection.setOnPolylineClickListener].
  */
-public inline fun PolylineManager.Collection.addPolyline(
-    optionsActions: PolylineOptions.() -> Unit
-): Polyline =
-    this.addPolyline(
-        PolylineOptions().apply(optionsActions)
-    )
+public fun PolylineManager.Collection.clickEvents(): Flow<Polyline> =
+    callbackFlow {
+        setOnPolylineClickListener {
+            trySend(it).isSuccess
+        }
+        awaitClose {
+            setOnPolylineClickListener(null)
+        }
+    }

--- a/maps-utils-ktx/src/test/java/com/google/maps/android/ktx/utils/clustering/ClusterManagerTest.kt
+++ b/maps-utils-ktx/src/test/java/com/google/maps/android/ktx/utils/clustering/ClusterManagerTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.utils.clustering
+
+import com.google.common.truth.Truth.assertThat
+import com.google.maps.android.clustering.Cluster
+import com.google.maps.android.clustering.ClusterItem
+import com.google.maps.android.clustering.ClusterManager
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(MockitoJUnitRunner::class)
+public class ClusterManagerTest {
+
+    @Mock
+    private lateinit var clusterManager: ClusterManager<ClusterItem>
+
+    @Mock
+    private lateinit var cluster: Cluster<ClusterItem>
+
+    @Mock
+    private lateinit var clusterItem: ClusterItem
+
+    @Captor
+    private lateinit var clusterClickListener: ArgumentCaptor<ClusterManager.OnClusterClickListener<ClusterItem>>
+
+    @Captor
+    private lateinit var clusterItemClickListener: ArgumentCaptor<ClusterManager.OnClusterItemClickListener<ClusterItem>>
+
+    @Captor
+    private lateinit var clusterInfoWindowClickListener: ArgumentCaptor<ClusterManager.OnClusterInfoWindowClickListener<ClusterItem>>
+
+    @Captor
+    private lateinit var clusterInfoWindowLongClickListener: ArgumentCaptor<ClusterManager.OnClusterInfoWindowLongClickListener<ClusterItem>>
+
+    @Captor
+    private lateinit var clusterItemInfoWindowClickListener: ArgumentCaptor<ClusterManager.OnClusterItemInfoWindowClickListener<ClusterItem>>
+
+    @Captor
+    private lateinit var clusterItemInfoWindowLongClickListener: ArgumentCaptor<ClusterManager.OnClusterItemInfoWindowLongClickListener<ClusterItem>>
+
+    @Test
+    public fun testClusterClickEvents(): Unit = runTest {
+        val job = launch {
+            val event = clusterManager.clusterClickEvents().first()
+            assertThat(event).isEqualTo(cluster)
+        }
+        advanceUntilIdle()
+        verify(clusterManager).setOnClusterClickListener(clusterClickListener.capture())
+        clusterClickListener.value.onClusterClick(cluster)
+        job.cancel()
+    }
+
+    @Test
+    public fun testClusterItemClickEvents(): Unit = runTest {
+        val job = launch {
+            val event = clusterManager.clusterItemClickEvents().first()
+            assertThat(event).isEqualTo(clusterItem)
+        }
+        advanceUntilIdle()
+        verify(clusterManager).setOnClusterItemClickListener(clusterItemClickListener.capture())
+        clusterItemClickListener.value.onClusterItemClick(clusterItem)
+        job.cancel()
+    }
+
+    @Test
+    public fun testClusterInfoWindowClickEvents(): Unit = runTest {
+        val job = launch {
+            val event = clusterManager.clusterInfoWindowClickEvents().first()
+            assertThat(event).isEqualTo(cluster)
+        }
+        advanceUntilIdle()
+        verify(clusterManager).setOnClusterInfoWindowClickListener(clusterInfoWindowClickListener.capture())
+        clusterInfoWindowClickListener.value.onClusterInfoWindowClick(cluster)
+        job.cancel()
+    }
+
+    @Test
+    public fun testClusterInfoWindowLongClickEvents(): Unit = runTest {
+        val job = launch {
+            val event = clusterManager.clusterInfoWindowLongClickEvents().first()
+            assertThat(event).isEqualTo(cluster)
+        }
+        advanceUntilIdle()
+        verify(clusterManager).setOnClusterInfoWindowLongClickListener(clusterInfoWindowLongClickListener.capture())
+        clusterInfoWindowLongClickListener.value.onClusterInfoWindowLongClick(cluster)
+        job.cancel()
+    }
+
+    @Test
+    public fun testClusterItemInfoWindowClickEvents(): Unit = runTest {
+        val job = launch {
+            val event = clusterManager.clusterItemInfoWindowClickEvents().first()
+            assertThat(event).isEqualTo(clusterItem)
+        }
+        advanceUntilIdle()
+        verify(clusterManager).setOnClusterItemInfoWindowClickListener(clusterItemInfoWindowClickListener.capture())
+        clusterItemInfoWindowClickListener.value.onClusterItemInfoWindowClick(clusterItem)
+        job.cancel()
+    }
+
+    @Test
+    public fun testClusterItemInfoWindowLongClickEvents(): Unit = runTest {
+        val job = launch {
+            val event = clusterManager.clusterItemInfoWindowLongClickEvents().first()
+            assertThat(event).isEqualTo(clusterItem)
+        }
+        advanceUntilIdle()
+        verify(clusterManager).setOnClusterItemInfoWindowLongClickListener(clusterItemInfoWindowLongClickListener.capture())
+        clusterItemInfoWindowLongClickListener.value.onClusterItemInfoWindowLongClick(clusterItem)
+        job.cancel()
+    }
+}

--- a/maps-utils-ktx/src/test/java/com/google/maps/android/ktx/utils/collection/CollectionManagersTest.kt
+++ b/maps-utils-ktx/src/test/java/com/google/maps/android/ktx/utils/collection/CollectionManagersTest.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.maps.android.ktx.utils.collection
+
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.model.Circle
+import com.google.android.gms.maps.model.GroundOverlay
+import com.google.android.gms.maps.model.Marker
+import com.google.android.gms.maps.model.Polygon
+import com.google.android.gms.maps.model.Polyline
+import com.google.common.truth.Truth.assertThat
+import com.google.maps.android.collections.CircleManager
+import com.google.maps.android.collections.GroundOverlayManager
+import com.google.maps.android.collections.MarkerManager
+import com.google.maps.android.collections.PolygonManager
+import com.google.maps.android.collections.PolylineManager
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(MockitoJUnitRunner::class)
+public class CollectionManagersTest {
+
+    @Mock
+    private lateinit var markerCollection: MarkerManager.Collection
+
+    @Mock
+    private lateinit var polylineCollection: PolylineManager.Collection
+
+    @Mock
+    private lateinit var polygonCollection: PolygonManager.Collection
+
+    @Mock
+    private lateinit var circleCollection: CircleManager.Collection
+
+    @Mock
+    private lateinit var groundOverlayCollection: GroundOverlayManager.Collection
+
+    @Mock
+    private lateinit var marker: Marker
+
+    @Mock
+    private lateinit var polyline: Polyline
+
+    @Mock
+    private lateinit var polygon: Polygon
+
+    @Mock
+    private lateinit var circle: Circle
+
+    @Mock
+    private lateinit var groundOverlay: GroundOverlay
+
+    @Captor
+    private lateinit var markerClickListener: ArgumentCaptor<GoogleMap.OnMarkerClickListener>
+
+    @Captor
+    private lateinit var infoWindowClickListener: ArgumentCaptor<GoogleMap.OnInfoWindowClickListener>
+
+    @Captor
+    private lateinit var infoWindowLongClickListener: ArgumentCaptor<GoogleMap.OnInfoWindowLongClickListener>
+
+    @Captor
+    private lateinit var polylineClickListener: ArgumentCaptor<GoogleMap.OnPolylineClickListener>
+
+    @Captor
+    private lateinit var polygonClickListener: ArgumentCaptor<GoogleMap.OnPolygonClickListener>
+
+    @Captor
+    private lateinit var circleClickListener: ArgumentCaptor<GoogleMap.OnCircleClickListener>
+
+    @Captor
+    private lateinit var groundOverlayClickListener: ArgumentCaptor<GoogleMap.OnGroundOverlayClickListener>
+
+    @Test
+    public fun testMarkerCollectionClickEvents(): Unit = runTest {
+        val job = launch {
+            val event = markerCollection.clickEvents().first()
+            assertThat(event).isEqualTo(marker)
+        }
+        advanceUntilIdle()
+        verify(markerCollection).setOnMarkerClickListener(markerClickListener.capture())
+        markerClickListener.value.onMarkerClick(marker)
+        job.cancel()
+    }
+
+    @Test
+    public fun testMarkerCollectionInfoWindowClickEvents(): Unit = runTest {
+        val job = launch {
+            val event = markerCollection.infoWindowClickEvents().first()
+            assertThat(event).isEqualTo(marker)
+        }
+        advanceUntilIdle()
+        verify(markerCollection).setOnInfoWindowClickListener(infoWindowClickListener.capture())
+        infoWindowClickListener.value.onInfoWindowClick(marker)
+        job.cancel()
+    }
+
+    @Test
+    public fun testMarkerCollectionInfoWindowLongClickEvents(): Unit = runTest {
+        val job = launch {
+            val event = markerCollection.infoWindowLongClickEvents().first()
+            assertThat(event).isEqualTo(marker)
+        }
+        advanceUntilIdle()
+        verify(markerCollection).setOnInfoWindowLongClickListener(infoWindowLongClickListener.capture())
+        infoWindowLongClickListener.value.onInfoWindowLongClick(marker)
+        job.cancel()
+    }
+
+    @Test
+    public fun testPolylineCollectionClickEvents(): Unit = runTest {
+        val job = launch {
+            val event = polylineCollection.clickEvents().first()
+            assertThat(event).isEqualTo(polyline)
+        }
+        advanceUntilIdle()
+        verify(polylineCollection).setOnPolylineClickListener(polylineClickListener.capture())
+        polylineClickListener.value.onPolylineClick(polyline)
+        job.cancel()
+    }
+
+    @Test
+    public fun testPolygonCollectionClickEvents(): Unit = runTest {
+        val job = launch {
+            val event = polygonCollection.clickEvents().first()
+            assertThat(event).isEqualTo(polygon)
+        }
+        advanceUntilIdle()
+        verify(polygonCollection).setOnPolygonClickListener(polygonClickListener.capture())
+        polygonClickListener.value.onPolygonClick(polygon)
+        job.cancel()
+    }
+
+    @Test
+    public fun testCircleCollectionClickEvents(): Unit = runTest {
+        val job = launch {
+            val event = circleCollection.clickEvents().first()
+            assertThat(event).isEqualTo(circle)
+        }
+        advanceUntilIdle()
+        verify(circleCollection).setOnCircleClickListener(circleClickListener.capture())
+        circleClickListener.value.onCircleClick(circle)
+        job.cancel()
+    }
+
+    @Test
+    public fun testGroundOverlayCollectionClickEvents(): Unit = runTest {
+        val job = launch {
+            val event = groundOverlayCollection.clickEvents().first()
+            assertThat(event).isEqualTo(groundOverlay)
+        }
+        advanceUntilIdle()
+        verify(groundOverlayCollection).setOnGroundOverlayClickListener(groundOverlayClickListener.capture())
+        groundOverlayClickListener.value.onGroundOverlayClick(groundOverlay)
+        job.cancel()
+    }
+}

--- a/maps-utils-ktx/src/test/java/com/google/maps/android/ktx/utils/collection/CollectionManagersTest.kt
+++ b/maps-utils-ktx/src/test/java/com/google/maps/android/ktx/utils/collection/CollectionManagersTest.kt
@@ -34,12 +34,15 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.Captor
 import org.mockito.Mock
+import org.mockito.Mockito.any
 import org.mockito.Mockito.verify
+import org.mockito.Mockito.times
 import org.mockito.junit.MockitoJUnitRunner
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -97,6 +100,18 @@ public class CollectionManagersTest {
     @Captor
     private lateinit var groundOverlayClickListener: ArgumentCaptor<GoogleMap.OnGroundOverlayClickListener>
 
+    private var activeMarkerClickListener: GoogleMap.OnMarkerClickListener? = null
+
+    @Before
+    public fun setUp() {
+        activeMarkerClickListener = null
+        // Stub setOnMarkerClickListener to track the active listener on the collection manager
+        org.mockito.Mockito.`when`(markerCollection.setOnMarkerClickListener(any())).thenAnswer { invocation ->
+            activeMarkerClickListener = invocation.arguments[0] as? GoogleMap.OnMarkerClickListener
+            null
+        }
+    }
+
     @Test
     public fun testMarkerCollectionClickEvents(): Unit = runTest {
         val job = launch {
@@ -104,9 +119,60 @@ public class CollectionManagersTest {
             assertThat(event).isEqualTo(marker)
         }
         advanceUntilIdle()
-        verify(markerCollection).setOnMarkerClickListener(markerClickListener.capture())
-        markerClickListener.value.onMarkerClick(marker)
+        // Trigger the event via our tracked active listener slot!
+        assertThat(activeMarkerClickListener).isNotNull()
+        activeMarkerClickListener?.onMarkerClick(marker)
         job.cancel()
+    }
+
+    @Test
+    public fun testConcurrentCollectionMarkerClick(): Unit = runTest {
+        val flow = markerCollection.clickEvents()
+        val collector1Events = mutableListOf<Marker>()
+        val collector2Events = mutableListOf<Marker>()
+
+        // Start Collector 1
+        val job1 = launch {
+            flow.collect { collector1Events.add(it) }
+        }
+        advanceUntilIdle()
+        assertThat(activeMarkerClickListener).isNotNull()
+        val listener1 = activeMarkerClickListener
+
+        // Start Collector 2 - this will overwrite the listener on the mock
+        val job2 = launch {
+            flow.collect { collector2Events.add(it) }
+        }
+        advanceUntilIdle()
+        val listener2 = activeMarkerClickListener
+
+        // Verify they are different listener instances and listener2 hijacked the slot
+        assertThat(listener1).isNotEqualTo(listener2)
+        assertThat(activeMarkerClickListener).isEqualTo(listener2)
+
+        // Simulate click via the active listener
+        activeMarkerClickListener?.onMarkerClick(marker)
+        advanceUntilIdle()
+
+        // Only collector 2 should receive the event because it hijacked the single-listener slot
+        assertThat(collector1Events).isEmpty()
+        assertThat(collector2Events).containsExactly(marker)
+
+        // Cancel collector 1. This triggers awaitClose and clears the listener slot (sets to null)
+        job1.cancel()
+        advanceUntilIdle()
+
+        // Assert that the active listener slot is now null!
+        assertThat(activeMarkerClickListener).isNull()
+
+        // Try to trigger a click again via the active listener (which is now null)
+        activeMarkerClickListener?.onMarkerClick(marker)
+        advanceUntilIdle()
+
+        // Collector 2 is now BROKEN and receives no further events because Collector 1's cleanup cleared the shared slot!
+        assertThat(collector2Events).containsExactly(marker)
+
+        job2.cancel()
     }
 
     @Test


### PR DESCRIPTION
This PR introduces comprehensive Kotlin Flow extensions to the `maps-utils-ktx` library, wrapping listener callbacks in `ClusterManager` and collection managers (`MarkerManager`, `PolylineManager`, `PolygonManager`, `CircleManager`, and `GroundOverlayManager`).

### 1. Kotlin Flow Extension Implementation 📦
Added clean `callbackFlow`-based extensions following standard KTX flow conventions:
*   **`ClusterManager`**: `clusterClickEvents()`, `clusterItemClickEvents()`, `clusterInfoWindowClickEvents()`, `clusterInfoWindowLongClickEvents()`, `clusterItemInfoWindowClickEvents()`, and `clusterItemInfoWindowLongClickEvents()`.
*   **Shape Collections**: Added `clickEvents()` to `MarkerManager.Collection` (including info window click/long-click flows), `PolylineManager.Collection`, `PolygonManager.Collection`, `CircleManager.Collection`, and `GroundOverlayManager.Collection`.
*   **Lifecycle Safety**: Updates subscribe/request callbacks *only* upon active subscription, and unregisters automatically on cancellation (`awaitClose`).

### 2. Asynchronous Unit Tests 🧪
Created dedicated unit tests validating event propagation and listener cleanup:
*   [ClusterManagerTest.kt](file:///usr/local/google/home/dkhawk/git/gmp-github/android-maps-ktx/feature-flow-extensions/maps-utils-ktx/src/test/java/com/google/maps/android/ktx/utils/clustering/ClusterManagerTest.kt)
*   [CollectionManagersTest.kt](file:///usr/local/google/home/dkhawk/git/gmp-github/android-maps-ktx/feature-flow-extensions/maps-utils-ktx/src/test/java/com/google/maps/android/ktx/utils/collection/CollectionManagersTest.kt)

---
### Verification Status
*   **All unit tests pass successfully with zero failures!**