### PR TITLE
build(deps): Upgrades android-maps-utils to 5.0.0-rc01

### DIFF
--- a/app/src/main/java/com/google/maps/android/ktx/demo/model/MyItem.kt
+++ b/app/src/main/java/com/google/maps/android/ktx/demo/model/MyItem.kt
@@ -26,9 +26,9 @@ import com.google.maps.android.clustering.ClusterItem
  *  (https://youtrack.jetbrains.com/issue/KT-6653?_ga=2.30406975.1494223917.1585591891-1137021041.1573759593)
  *  so we must name our fields differently and then pass them to the ClusterItem methods.
  */
-data class MyItem(val latLng: LatLng, val myTitle: String?, val mySnippet: String?, val myZIndex: Float?) : ClusterItem {
-    override fun getPosition() = latLng
-    override fun getTitle() = myTitle
-    override fun getSnippet() = mySnippet
-    override fun getZIndex() = myZIndex
-}
+data class MyItem(
+    override val position: LatLng,
+    override val title: String?,
+    override val snippet: String?,
+    override val zIndex: Float?
+) : ClusterItem

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ androidxStartup = "1.2.0"
 # --- Google Maps ---
 # Versions for Google Play Services libraries, which are essential for this sample.
 androidMapsSdk = "20.0.0"
-androidMapsUtils = "4.4.0"
+androidMapsUtils = "5.0.0-rc01"
 
 # --- Testing ---
 # Versions for testing libraries.


### PR DESCRIPTION
Upgrades the Android Maps Utils dependency to the latest 5.0.0 release candidate (5.0.0-rc01).

With the conversion of Android Maps Utils 5.0.0 to Kotlin, `ClusterItem` now exposes Kotlin properties instead of Java getter methods. Consequently, `MyItem` in the demo application has been refactored to directly override the `position`, `title`, `snippet`, and `zIndex` properties rather than implementing the legacy getter methods.