### PR TITLE
docs: update lifecycle coroutine example

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,10 @@ override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     val mapFragment = supportFragmentManager.findFragmentById(R.id.map) as? SupportMapFragment
 
-    lifecycle.coroutineScope.launchWhenCreated {
-        val googleMap = mapFragment?.awaitMap()
+    lifecycleScope.launch {
+        lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
+            val googleMap = mapFragment?.awaitMap()
+        }
     }
 }
 ```


### PR DESCRIPTION
Fixes #195 🦕

## Summary

- replace the deprecated `launchWhenCreated` README usage with `repeatOnLifecycle`
- match the lifecycle-aware coroutine pattern used by the demo app

## Validation

- `./gradlew build jacocoTestReport --stacktrace`
- `./gradlew lint`
