### PR TITLE
feat: add coroutine Maps SDK initialization

### DIFF
--- a/maps-ktx/src/main/java/com/google/maps/android/ktx/MapsInitializer.kt
+++ b/maps-ktx/src/main/java/com/google/maps/android/ktx/MapsInitializer.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.maps.android.ktx
+
+import android.content.Context
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException
+import com.google.android.gms.maps.MapsInitializer
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Initializes the Maps SDK and returns the [MapsInitializer.Renderer] that was actually loaded.
+ *
+ * This function does not support cancellation because [MapsInitializer.initialize] cannot cancel
+ * initialization. Only the first Maps SDK initialization in an application lifecycle honors
+ * [preferredRenderer]; `null` uses the SDK's default preference.
+ *
+ * @param preferredRenderer the renderer to request, or `null` to use the default preference
+ * @return the renderer actually loaded by the Maps SDK
+ * @throws GooglePlayServicesNotAvailableException if initialization returns a status other than
+ * [ConnectionResult.SUCCESS] without invoking the callback
+ */
+public suspend inline fun Context.awaitMapsSdkInitialized(
+    preferredRenderer: MapsInitializer.Renderer? = null
+): MapsInitializer.Renderer =
+    suspendCoroutine { continuation ->
+        var callbackInvoked = false
+        val status = MapsInitializer.initialize(this, preferredRenderer) { renderer ->
+            callbackInvoked = true
+            continuation.resume(renderer)
+        }
+        if (!callbackInvoked && status != ConnectionResult.SUCCESS) {
+            continuation.resumeWithException(GooglePlayServicesNotAvailableException(status))
+        }
+    }

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/MapsInitializerTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/MapsInitializerTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.maps.android.ktx
+
+import android.content.Context
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException
+import com.google.android.gms.maps.MapsInitializer
+import com.google.android.gms.maps.OnMapsSdkInitializedCallback
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mock
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mockStatic
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+public class MapsInitializerTest {
+
+    @Mock
+    private lateinit var context: Context
+
+    private lateinit var mapsInitializerMock: MockedStatic<MapsInitializer>
+
+    @Before
+    public fun setUp() {
+        mapsInitializerMock = mockStatic(MapsInitializer::class.java)
+    }
+
+    @After
+    public fun tearDown() {
+        mapsInitializerMock.close()
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    public fun testAwaitMapsSdkInitializedReturnsActualRenderer(): Unit = runTest {
+        mapsInitializerMock.`when`<Int> {
+            MapsInitializer.initialize(
+                eq(context),
+                eq(MapsInitializer.Renderer.LATEST),
+                any(OnMapsSdkInitializedCallback::class.java)
+            )
+        }.thenAnswer { invocation ->
+            invocation.getArgument<OnMapsSdkInitializedCallback>(2)
+                .onMapsSdkInitialized(MapsInitializer.Renderer.LEGACY)
+            ConnectionResult.SUCCESS
+        }
+
+        val renderer = context.awaitMapsSdkInitialized(MapsInitializer.Renderer.LATEST)
+
+        assertThat(renderer).isEqualTo(MapsInitializer.Renderer.LEGACY)
+    }
+
+    @Test
+    public fun testAwaitMapsSdkInitializedThrowsForNonSuccessStatus(): Unit = runTest {
+        mapsInitializerMock.`when`<Int> {
+            MapsInitializer.initialize(
+                eq(context),
+                eq(MapsInitializer.Renderer.LATEST),
+                any(OnMapsSdkInitializedCallback::class.java)
+            )
+        }.thenReturn(ConnectionResult.SERVICE_MISSING)
+
+        val exception = runCatching {
+            context.awaitMapsSdkInitialized(MapsInitializer.Renderer.LATEST)
+        }.exceptionOrNull()
+
+        assertThat(exception).isInstanceOf(GooglePlayServicesNotAvailableException::class.java)
+        assertThat((exception as GooglePlayServicesNotAvailableException).errorCode)
+            .isEqualTo(ConnectionResult.SERVICE_MISSING)
+    }
+}

--- a/maps-ktx/src/test/java/com/google/maps/android/ktx/MapsInitializerTest.kt
+++ b/maps-ktx/src/test/java/com/google/maps/android/ktx/MapsInitializerTest.kt
@@ -90,4 +90,44 @@ public class MapsInitializerTest {
         assertThat((exception as GooglePlayServicesNotAvailableException).errorCode)
             .isEqualTo(ConnectionResult.SERVICE_MISSING)
     }
+
+    @Suppress("DEPRECATION")
+    @Test
+    public fun testAwaitMapsSdkInitializedWithNullPreferredRenderer(): Unit = runTest {
+        mapsInitializerMock.`when`<Int> {
+            MapsInitializer.initialize(
+                eq(context),
+                eq(null),
+                any(OnMapsSdkInitializedCallback::class.java)
+            )
+        }.thenAnswer { invocation ->
+            invocation.getArgument<OnMapsSdkInitializedCallback>(2)
+                .onMapsSdkInitialized(MapsInitializer.Renderer.LATEST)
+            ConnectionResult.SUCCESS
+        }
+
+        val renderer = context.awaitMapsSdkInitialized(null)
+
+        assertThat(renderer).isEqualTo(MapsInitializer.Renderer.LATEST)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    public fun testAwaitMapsSdkInitializedWithDefaultNullRenderer(): Unit = runTest {
+        mapsInitializerMock.`when`<Int> {
+            MapsInitializer.initialize(
+                eq(context),
+                eq(null),
+                any(OnMapsSdkInitializedCallback::class.java)
+            )
+        }.thenAnswer { invocation ->
+            invocation.getArgument<OnMapsSdkInitializedCallback>(2)
+                .onMapsSdkInitialized(MapsInitializer.Renderer.LATEST)
+            ConnectionResult.SUCCESS
+        }
+
+        val renderer = context.awaitMapsSdkInitialized()
+
+        assertThat(renderer).isEqualTo(MapsInitializer.Renderer.LATEST)
+    }
 }


### PR DESCRIPTION
Fixes #228

- Add `Context.awaitMapsSdkInitialized()` for coroutine-based Maps SDK initialization.
- Return the renderer actually loaded and preserve the optional renderer preference.
- Throw `GooglePlayServicesNotAvailableException` with the SDK status code on initialization failure.
- Add focused success and failure coverage.

## Verification

- `./gradlew :maps-ktx:testDebugUnitTest --tests 'com.google.maps.android.ktx.MapsInitializerTest'`
- `./gradlew :maps-ktx:testDebugUnitTest :maps-ktx:lintDebug`
- `./gradlew build jacocoTestReport`
- `git diff --check`

## Limitations

- Live Play Services initialization was not exercised on a device or emulator; the callback and status contracts are covered with static mocks and verified against Maps SDK 20.0.0 bytecode.
