### PR TITLE
build(deps): upgrade android-maps-utils to 5.2.0 and update dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,13 +62,13 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlin {
         compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
         }
     }
 
@@ -95,6 +95,8 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.bytebuddy)
+    testImplementation(libs.bytebuddy.agent)
     testImplementation(libs.truth)
     testImplementation(libs.kotlinx.coroutines.test)
 

--- a/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/PublishingConventionPlugin.kt
@@ -28,7 +28,7 @@ class PublishingConventionPlugin : Plugin<Project> {
 
     private fun Project.configureJacoco() {
         configure<JacocoPluginExtension> {
-            toolVersion = "0.8.12"
+            toolVersion = "0.8.15"
         }
 
         tasks.withType<Test>().configureEach {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ truth = "1.4.5"
 
 # --- Gradle Plugins ---
 # Versions for Gradle plugins used in the build process.
-agp = "9.3.1"
+agp = "9.4.0"
 dokkaGradlePlugin = "2.2.0"
 gradleMavenPublishPlugin = "0.37.0"
 jacocoAndroidGradlePlugin = "0.2.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,12 +5,12 @@ androidCompileSdk = "37"
 androidMinSdk = "23"
 androidTargetSdk = "37"
 
-androidxAppcompat = "1.7.1"
+androidxAppcompat = "1.8.0"
 androidxCoreKtx = "1.19.0"
 # Increasing androidxActivityKtx or lifecycleRuntimeKtx will require us to upgrade the minSdk
 androidxActivityKtx = "1.13.0"
 lifecycleRuntimeKtx = "2.11.0"
-kotlin = "2.4.0"
+kotlin = "2.4.10"
 kotlinxCoroutines = "1.11.0"
 material = "1.14.0"
 androidxStartup = "1.2.0"
@@ -18,7 +18,7 @@ androidxStartup = "1.2.0"
 # --- Google Maps & Location ---
 # Versions for Google Play Services libraries, which are essential for this sample.
 androidMapsSdk = "20.0.0"
-androidMapsUtils = "5.1.0"
+androidMapsUtils = "5.2.0"
 playServicesLocation = "21.4.0"
 
 # --- Testing ---
@@ -35,7 +35,7 @@ truth = "1.4.5"
 
 # --- Gradle Plugins ---
 # Versions for Gradle plugins used in the build process.
-agp = "9.2.1"
+agp = "9.3.1"
 dokkaGradlePlugin = "2.2.0"
 gradleMavenPublishPlugin = "0.37.0"
 jacocoAndroidGradlePlugin = "0.2.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/maps-ktx/build.gradle.kts
+++ b/maps-ktx/build.gradle.kts
@@ -48,15 +48,15 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
 
     kotlin {
         compilerOptions {
             freeCompilerArgs.add("-Xexplicit-api=strict")
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
         }
     }
 
@@ -88,6 +88,8 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.bytebuddy)
+    testImplementation(libs.bytebuddy.agent)
     testImplementation(libs.truth)
     testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/maps-utils-ktx/build.gradle.kts
+++ b/maps-utils-ktx/build.gradle.kts
@@ -48,14 +48,14 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlin {
         compilerOptions {
             freeCompilerArgs.add("-Xexplicit-api=strict")
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
         }
     }
 


### PR DESCRIPTION
## Description
- Upgrades `android-maps-utils` from 5.1.0 to 5.2.0
- Upgrades AGP to 9.4.0
- Upgrades Kotlin to 2.4.10
- Upgrades `androidx.appcompat` to 1.8.0
- Upgrades Gradle wrapper to 9.7.1
- Upgrades JaCoCo to 0.8.15
- Updates JVM and Kotlin compilation bytecode targets to Java 17 across all modules
- Adds bytebuddy test dependencies for modern JDK Mockito dynamic agent loading support

All unit tests and lint checks passed.