### PR TITLE
build: retain JVM bytecode target at Java 1.8 across all modules

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,13 +62,13 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlin {
         compilerOptions {
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
         }
     }
 

--- a/maps-ktx/build.gradle.kts
+++ b/maps-ktx/build.gradle.kts
@@ -48,15 +48,15 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
 
     kotlin {
         compilerOptions {
             freeCompilerArgs.add("-Xexplicit-api=strict")
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
         }
     }
 

--- a/maps-utils-ktx/build.gradle.kts
+++ b/maps-utils-ktx/build.gradle.kts
@@ -48,14 +48,14 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlin {
         compilerOptions {
             freeCompilerArgs.add("-Xexplicit-api=strict")
-            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
         }
     }
 


### PR DESCRIPTION
## Description
Reverts JVM bytecode target and compile options from Java 17 back to Java 1.8 across `app`, `maps-ktx`, and `maps-utils-ktx` to maintain backward compatibility for consumers.

### Changes:
- **`app/build.gradle.kts`**: Set `sourceCompatibility`/`targetCompatibility` and `jvmTarget` back to Java 1.8.
- **`maps-ktx/build.gradle.kts`**: Set `sourceCompatibility`/`targetCompatibility` and `jvmTarget` back to Java 1.8.
- **`maps-utils-ktx/build.gradle.kts`**: Set `sourceCompatibility`/`targetCompatibility` and `jvmTarget` back to Java 1.8.

### Verification:
- All unit tests (`./gradlew test`) passed locally.
- All Android Lint and analysis tasks (`./gradlew check`) passed locally.